### PR TITLE
Shifted to deprecated `new Buffer()` function for full node v4 compatibility

### DIFF
--- a/npm/cache.js
+++ b/npm/cache.js
@@ -21,7 +21,7 @@ createBundle = function (options, file, done) {
         },
 
         function (buf, next) {
-            fs.writeFile(file, `module.exports=function(d){d(null, Buffer.from(${JSON.stringify(buf)}.data));};`, next);
+            fs.writeFile(file, `module.exports=function(d){d(null, new Buffer(${JSON.stringify(buf)}.data));};`, next);
         },
 
         function (next) {


### PR DESCRIPTION
This fixes issue reported at https://github.com/postmanlabs/newman/issues/855

`new Buffer` is deprecated. However, this is a controlled code usage and buffer content, so security aspects of the same is greatly minimised.