### PR TITLE
Added support for XPath and DOMParser

### DIFF
--- a/lib/sandbox/legacy-execute.js
+++ b/lib/sandbox/legacy-execute.js
@@ -15,7 +15,9 @@ var Scope = require('uniscope'),
         tv4: require('tv4'),
         xml2Json: require('./xml2Json'),
         Backbone: require('backbone'),
-        cheerio: require('cheerio')
+        cheerio: require('cheerio'),
+        xpath: require('xpath'),
+        DOMParser: require('xmldom').DOMParser
     };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "inherits": "2.0.3",
     "lodash": "4.17.2",
     "uuid": "3.0.1",
-    "uvm": "1.4.0"
+    "uvm": "1.4.0",
+    "xmldom": "0.1.27",
+    "xpath": "0.0.23"
   },
   "devDependencies": {
     "assert": "1.4.1",

--- a/test/unit/sandbox-libraries/xmldom.test.js
+++ b/test/unit/sandbox-libraries/xmldom.test.js
@@ -1,0 +1,53 @@
+describe('sandbox library - xmldom', function () {
+    this.timeout(1000 * 60);
+    var Sandbox = require('../../../'),
+        context,
+        markup = `
+            <?xml version="1.0" encoding="utf-8"?>
+            <response version="1.0">
+                <time>20</time>
+                <results>
+                    <total>1</total>
+                    <docs>
+                        <doc>                     
+                            <identifiers>
+                                <doi>10.2766/65538</doi>
+                                <isbn>978-92-79-37860-7</isbn>
+                                <catalogue_number>NC-02-13-772-02-N</catalogue_number>
+                            </identifiers>                            
+                            <publicationDate>2014-12-08</publicationDate>                     
+                        </doc>                                                                 
+                    </docs>
+                </results>
+            </response>`;
+
+    beforeEach(function (done) {
+        Sandbox.createContext({debug: true}, function (err, ctx) {
+            context = ctx;
+            done(err);
+        });
+    });
+
+    afterEach(function () {
+        context.dispose();
+        context = null;
+    });
+
+    it('must exist', function (done) {
+        context.execute(`
+            var assert = require('assert');
+            assert.strictEqual(typeof DOMParser, 'function', 'typeof DOMParser must be object');          
+        `, done);
+    });
+
+    describe('basic functionality', function () {
+        it('must have basic functionality working', function (done) {
+            context.execute(`
+                var assert = require('assert'),
+                    doc =  new DOMParser().parseFromString(\`${markup}\`, 'text/xml');
+                assert.strictEqual(doc.getElementsByTagName('response').length, 1, 'Parsing must be valid');
+                assert.strictEqual(doc.getElementsByTagName('time')[0].textContent, '20', 'Parsing must be valid');                
+            `, done);
+        });
+    });
+});

--- a/test/unit/sandbox-libraries/xpath.test.js
+++ b/test/unit/sandbox-libraries/xpath.test.js
@@ -1,0 +1,68 @@
+describe('sandbox library - xpath', function () {
+    this.timeout(1000 * 60);
+    var Sandbox = require('../../../'),
+        context,
+        markup = `
+            <?xml version="1.0" encoding="utf-8"?>
+            <response version="1.0">
+                <time>20</time>
+                <results>
+                    <total>1</total>
+                    <docs>
+                        <doc>                     
+                            <identifiers>
+                                <doi>10.2766/65538</doi>
+                                <isbn>978-92-79-37860-7</isbn>
+                                <catalogue_number>NC-02-13-772-02-N</catalogue_number>
+                            </identifiers>                            
+                            <publicationDate>2014-12-08</publicationDate>                     
+                        </doc>                                                                 
+                    </docs>
+                </results>
+            </response>`;
+
+    beforeEach(function (done) {
+        Sandbox.createContext({debug: true}, function (err, ctx) {
+            context = ctx;
+            done(err);
+        });
+    });
+
+    afterEach(function () {
+        context.dispose();
+        context = null;
+    });
+
+    it('must exist', function (done) {
+        context.execute(`
+            var assert = require('assert');            
+            assert.strictEqual(typeof xpath, 'object', 'typeof xpath must be object');
+            assert.strictEqual(typeof xpath.XPathResult, 'function', 'typeof xpath.XPathResult must be object');
+            assert.strictEqual(typeof xpath.evaluate, 'function', 'typeof xpath.evaluate must be function');
+            assert.strictEqual(typeof xpath.select, 'function', 'typeof xpath.select must be function');
+        `, done);
+    });
+
+    describe('basic functionality', function () {
+        it('must work with select', function (done) {
+            context.execute(`
+                var assert = require('assert'),                                     
+                    xmlDoc = new DOMParser().parseFromString(\`${markup}\`, 'text/xml');
+                   
+                assert.strictEqual(xpath.select('/response/time/text()', xmlDoc)[0].toString(), '20', 'Node extraction must work correctly');
+                
+            `, done);
+        });
+
+        it('must work with evaluate', function (done) {
+            context.execute(`
+                var assert = require('assert'),                                     
+                    xmlDoc = new DOMParser().parseFromString(\`${markup}\`, 'text/xml');                   
+                assert.strictEqual(xpath.evaluate('boolean(/response/time)', xmlDoc, null, xpath.XPathResult.STRING_TYPE, null).stringValue, 'true', 'Node extraction must work correctly');
+                
+            `, done);
+        });
+
+
+    });
+});


### PR DESCRIPTION
This merge request adds support for XPath in order to allow testing REST/XML APIs in Newman using XPath