### PR TITLE
request and response assertion basics (using chai)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Postman Sandbox Changelog
 
+#### Unreleased
+* added request and response assertions in form of `pm.request.to` and `pm.response.to`
+* `pm.cookies are made available`
+
 #### 2.1.0 (April 13, 2017)
 * Initial release of the `pm` API.
 * `pm.globals`, `pm.environment` - [VariableScope](http://www.postmanlabs.com/postman-collection/VariableScope.html)s

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -21,7 +21,8 @@ module.exports = {
         assert: {glob: true},
         'postman-collection': {expose: 'postman-collection', glob: true},
         uuid: {resolve: '../vendor/uuid', expose: 'uuid', glob: true},
-        chai: {glob: true}
+        chai: {glob: true},
+        lodash: {glob: true}
     },
     ignore: ['aws4', 'hawk', 'node-oauth1'],
     files: {

--- a/lib/sandbox/chai-postman.js
+++ b/lib/sandbox/chai-postman.js
@@ -21,6 +21,7 @@ var sdk = require('postman-collection'),
         withoutContent: 204, // @todo add 1223 status code
         badRequest: 400,
         unauthorised: 401,
+        unauthorized: 401,
         forbidden: 403,
         notFound: 404,
         notAcceptable: 406,

--- a/lib/sandbox/chai-postman.js
+++ b/lib/sandbox/chai-postman.js
@@ -138,7 +138,7 @@ module.exports = function (chai) {
         new Assertion(this._obj).to.have.property('reason');
         new Assertion(this._obj.reason).to.be.a('function');
 
-        var wantedReason = String(reason).toUpperCase(),
+        var wantedReason = 'OK',
             actualReason = String(this._obj.reason()).toUpperCase();
 
         this.assert(actualReason === wantedReason,
@@ -271,6 +271,47 @@ module.exports = function (chai) {
             'expected response body to equal #{exp} but got #{act}',
             'expected response body to not equal #{exp}',
             content, bodyData);
+
+    });
+
+    Assertion.addMethod('jsonBody', function (path, value) {
+        new Assertion(this._obj).to.be.postmanResponse;
+        new Assertion(this._obj).to.have.property('json');
+        new Assertion(this._obj.json).to.be.a('function');
+
+        var parseError,
+            jsonBody;
+
+        try { jsonBody = this._obj.json(); }
+        catch (e) {
+            if (e.name === 'JSONError' && e.message) {
+                parseError = e.message.replace(FIRST_LINE, '$1');
+            }
+            else {
+                parseError = e.name + ': ' + e.message;
+            }
+        }
+
+        if (arguments.length === 0) {
+            this.assert(!parseError, 'expected response body to be a valid json but got error ' + parseError,
+                'expected response body not to be a valid json');
+            return;
+        }
+
+        if (_.isString(path)) {
+            this.assert(_.has(jsonBody, path),
+                    'expected #{act} in response to contain property #{exp}',
+                    'expected #{act} in response to not contain property #{exp}',
+                    path, jsonBody);
+
+            if (arguments.length > 1) {
+                jsonBody = _.get(jsonBody, path);
+                this.assert(_.isEqual(jsonBody, value),
+                    'expected response body json at "' + path + '" to contain #{exp} but got #{act}',
+                    'expected response body json at "' + path + '" to not contain #{exp} but got #{act}',
+                    value, jsonBody);
+            }
+        }
 
     });
 

--- a/lib/sandbox/chai-postman.js
+++ b/lib/sandbox/chai-postman.js
@@ -1,0 +1,185 @@
+var sdk = require('postman-collection'),
+    _ = require('lodash'),
+
+    FIRST_LINE = /(.*?)\n.*/g,
+
+    requestOrResponse = function (what) {
+        return sdk.Request.isRequest(what) && 'request' || sdk.Response.isResponse(what) && 'response' || undefined;
+    },
+
+    statusClassReasons = {
+        info: 1,
+        success: 2,
+        redirection: 3,
+        clientError: 4,
+        serverError: 5
+    },
+
+    statusCodeReasons = {
+        ok: 200,
+        accepted: 202,
+        withoutContent: 204, // @todo add 1223 status code
+        badRequest: 400,
+        unauthorised: 401,
+        forbidden: 403,
+        notFound: 404,
+        notAcceptable: 406,
+        rateLimited: 429
+    };
+
+module.exports = function (chai) {
+    var Assertion = chai.Assertion;
+
+    Assertion.addMethod('statusCodeClass', function (classCode) {
+        new Assertion(this._obj).to.have.property('code');
+        new Assertion(this._obj.code).to.be.a('number');
+
+        var statusClass = Math.floor(this._obj.code / 100);
+        this.assert(statusClass === classCode,
+            'expected response code to be #{exp}XX but found #{act}',
+            'expected response code to not be #{exp}XX',
+            classCode, this._obj.code);
+    });
+
+    _.forOwn(statusClassReasons, function (classCode, reason) {
+        Assertion.addProperty(reason, function () {
+            new Assertion(this._obj).to.have.property('code');
+            new Assertion(this._obj.code).to.be.a('number');
+
+            var statusClass = Math.floor(this._obj.code / 100);
+            this.assert(statusClass === classCode,
+                'expected response code to be #{exp}XX but found #{act}',
+                'expected response code to not be #{exp}XX',
+                classCode, this._obj.code);
+        });
+    });
+
+    Assertion.addProperty('error', function () {
+        new Assertion(this._obj).to.have.property('code');
+        new Assertion(this._obj.code).to.be.a('number');
+
+        var statusClass = Math.floor(this._obj.code / 100);
+        this.assert(statusClass === 4 || statusClass === 5,
+            'expected response code to be 4XX or 5XX but found #{act}',
+            'expected response code to not be 4XX or 5XX',
+            null, this._obj.code);
+    });
+
+    Assertion.addMethod('statusCode', function (code) {
+        new Assertion(this._obj).to.have.property('code');
+        new Assertion(this._obj.code).to.be.a('number');
+
+        this.assert(this._obj.code === Number(code),
+            'expected response to have status code #{exp} but got #{act}',
+            'expected response to not have status code #{act}',
+            Number(code), this._obj.code);
+    });
+
+    Assertion.addMethod('statusReason', function (reason) {
+        new Assertion(this._obj).to.have.property('reason');
+        new Assertion(this._obj.reason).to.be.a('function');
+
+        reason = String(reason);
+
+        this.assert(this._obj.reason() === reason,
+            'expected response to have status reason #{exp} but got #{act}',
+            'expected response to not have status reason #{act}',
+            reason, this._obj.reason());
+    });
+
+    _.forOwn(statusCodeReasons, function (statusCode, reason) {
+        Assertion.addProperty(reason, function () {
+            new Assertion(this._obj).to.have.property('reason');
+            new Assertion(this._obj.reason).to.be.a('function');
+
+            var wantedReason = String(reason).toUpperCase(),
+                actualReason = String(this._obj.reason()).toUpperCase();
+
+            this.assert(actualReason === wantedReason,
+                'expected response to have status reason #{exp} but got #{act}',
+                'expected response to not have status reason #{act}',
+                wantedReason, actualReason);
+        });
+    });
+
+    Assertion.addMethod('status', function (codeOrReason) {
+        if (_.isNumber(codeOrReason)) {
+            new Assertion(this._obj).to.have.property('code');
+            new Assertion(this._obj.code).to.be.a('number');
+
+            this.assert(this._obj.code === Number(codeOrReason),
+                'expected response to have status code #{exp} but got #{act}',
+                'expected response to not have status code #{act}',
+                Number(codeOrReason), this._obj.code);
+        }
+        else {
+            new Assertion(this._obj).to.have.property('reason');
+            new Assertion(this._obj.reason).to.be.a('function');
+
+            this.assert(this._obj.reason() === codeOrReason,
+                'expected response to have status reason #{exp} but got #{act}',
+                'expected response to not have status reason #{act}',
+                codeOrReason, this._obj.reason());
+        }
+    });
+
+    Assertion.addMethod('header', function (headerKey, headerValue) {
+        new Assertion(this._obj).to.have.property('headers');
+
+        var ror = requestOrResponse(this._obj);
+
+        this.assert(this._obj.headers.has(headerKey),
+            'expected ' + ror + ' to have header with key #{exp}',
+            'expected ' + ror + ' to not have header with key #{exp}',
+            headerKey);
+
+        if (arguments.length < 2) { return; } // in case no check is done on value
+
+        this.assert(this._obj.headers.one(headerKey).value === headerValue,
+            'expected \'' + String(headerKey) + '\' ' + ror + ' header to be #{exp} but got #{act}',
+            'expected \'' + String(headerKey) + '\' ' + ror + ' header to not be #{act}',
+            headerValue, this._obj.headers.one(headerKey).value);
+    });
+
+    Assertion.addProperty('withBody', function () {
+        new Assertion(this._obj).to.have.property('text');
+        new Assertion(this._obj.json).to.be.a('function');
+
+        var bodyText = this._obj.text();
+
+        this.assert(_.isString(bodyText) && bodyText.length,
+            'expected response to have content in body',
+            'expected response to not have content in body');
+    });
+
+    Assertion.addProperty('jsonBody', function () {
+        new Assertion(this._obj).to.have.property('json');
+        new Assertion(this._obj.json).to.be.a('function');
+
+        var parseError;
+
+        try { this._obj.json(); }
+        catch (e) {
+            if (e.name === 'JSONError' && e.message) {
+                parseError = e.message.replace(FIRST_LINE, '$1');
+            }
+            else {
+                parseError = e.name + ': ' + e.message;
+            }
+        }
+
+        this.assert(!parseError,
+            'expected response body to be a valid json but got error ' + parseError,
+            'expected response body not to be a valid json');
+
+    });
+
+    // @todo add tests for:
+    // 1. request and response content type
+    // 2. response encoding
+    // 3. response time
+    // 4. response size
+    // 5. cookies
+    // 6. assert on http/https
+    // 7. assert property "secured" and include auth flags
+};

--- a/lib/sandbox/chai-postman.js
+++ b/lib/sandbox/chai-postman.js
@@ -30,7 +30,26 @@ var sdk = require('postman-collection'),
 module.exports = function (chai) {
     var Assertion = chai.Assertion;
 
+    Assertion.addProperty('postmanRequest', function () {
+        this.assert(sdk.Request.isRequest(this._obj),
+            'expecting a postman request object but got #{this}',
+            'not expecting a postman request object');
+    });
+
+    Assertion.addProperty('postmanResponse', function () {
+        this.assert(sdk.Response.isResponse(this._obj),
+            'expecting a postman response object but got #{this}',
+            'not expecting a postman response object');
+    });
+
+    Assertion.addProperty('postmanRequestOrResponse', function () {
+        this.assert(sdk.Response.isResponse(this._obj) || sdk.Request.isRequest(this._obj),
+            'expecting a postman request or response object but got #{this}',
+            'not expecting a postman request or response object');
+    });
+
     Assertion.addMethod('statusCodeClass', function (classCode) {
+        new Assertion(this._obj).to.be.postmanResponse;
         new Assertion(this._obj).to.have.property('code');
         new Assertion(this._obj.code).to.be.a('number');
 
@@ -43,6 +62,7 @@ module.exports = function (chai) {
 
     _.forOwn(statusClassReasons, function (classCode, reason) {
         Assertion.addProperty(reason, function () {
+            new Assertion(this._obj).to.be.postmanResponse;
             new Assertion(this._obj).to.have.property('code');
             new Assertion(this._obj.code).to.be.a('number');
 
@@ -55,6 +75,7 @@ module.exports = function (chai) {
     });
 
     Assertion.addProperty('error', function () {
+        new Assertion(this._obj).to.be.postmanResponse;
         new Assertion(this._obj).to.have.property('code');
         new Assertion(this._obj.code).to.be.a('number');
 
@@ -66,6 +87,7 @@ module.exports = function (chai) {
     });
 
     Assertion.addMethod('statusCode', function (code) {
+        new Assertion(this._obj).to.be.postmanResponse;
         new Assertion(this._obj).to.have.property('code');
         new Assertion(this._obj.code).to.be.a('number');
 
@@ -76,6 +98,7 @@ module.exports = function (chai) {
     });
 
     Assertion.addMethod('statusReason', function (reason) {
+        new Assertion(this._obj).to.be.postmanResponse;
         new Assertion(this._obj).to.have.property('reason');
         new Assertion(this._obj.reason).to.be.a('function');
 
@@ -89,6 +112,7 @@ module.exports = function (chai) {
 
     _.forOwn(statusCodeReasons, function (statusCode, reason) {
         Assertion.addProperty(reason, function () {
+            new Assertion(this._obj).to.be.postmanResponse;
             new Assertion(this._obj).to.have.property('reason');
             new Assertion(this._obj.reason).to.be.a('function');
 
@@ -103,6 +127,8 @@ module.exports = function (chai) {
     });
 
     Assertion.addMethod('status', function (codeOrReason) {
+        new Assertion(this._obj).to.be.postmanResponse;
+
         if (_.isNumber(codeOrReason)) {
             new Assertion(this._obj).to.have.property('code');
             new Assertion(this._obj.code).to.be.a('number');
@@ -124,6 +150,7 @@ module.exports = function (chai) {
     });
 
     Assertion.addMethod('header', function (headerKey, headerValue) {
+        new Assertion(this._obj).to.be.postmanRequestOrResponse;
         new Assertion(this._obj).to.have.property('headers');
 
         var ror = requestOrResponse(this._obj);
@@ -142,6 +169,7 @@ module.exports = function (chai) {
     });
 
     Assertion.addProperty('withBody', function () {
+        new Assertion(this._obj).to.be.postmanResponse;
         new Assertion(this._obj).to.have.property('text');
         new Assertion(this._obj.json).to.be.a('function');
 
@@ -153,6 +181,7 @@ module.exports = function (chai) {
     });
 
     Assertion.addProperty('jsonBody', function () {
+        new Assertion(this._obj).to.be.postmanResponse;
         new Assertion(this._obj).to.have.property('json');
         new Assertion(this._obj.json).to.be.a('function');
 

--- a/lib/sandbox/chai-postman.js
+++ b/lib/sandbox/chai-postman.js
@@ -224,6 +224,56 @@ module.exports = function (chai) {
 
     });
 
+    Assertion.addMethod('body', function (content) {
+        var bodyData;
+        new Assertion(this._obj).to.be.postmanResponse;
+
+        // assert equality with json
+        if (_.isPlainObject(content)) {
+            new Assertion(this._obj).to.have.property('json');
+            new Assertion(this._obj.json).to.be.a('function');
+
+            try { bodyData = this._obj.json(); }
+            catch (e) { } // eslint-disable-line no-empty
+
+
+            this.assert(_.isEqual(bodyData, content),
+                'expected response body json to equal #{exp} but got #{act}',
+                'expected response body json to not equal #{exp} but got #{act}',
+                content, bodyData);
+
+            return;
+        }
+
+        new Assertion(this._obj).to.have.property('text');
+        new Assertion(this._obj.text).to.be.a('function');
+        bodyData = this._obj.text();
+
+        // assert only presence of body
+        if (arguments.length === 0) {
+            this.assert(_.isString(bodyData) && bodyData.length,
+                'expected response to have content in body',
+                'expected response to not have content in body');
+            return;
+        }
+
+        // assert regexp
+        if (content instanceof RegExp) {
+            this.assert(content.exec(bodyData) !== null,
+                'expected response body text to match #{exp} but got #{act}',
+                'expected response body text #{act} to not match #{exp}',
+                content, bodyData);
+            return;
+        }
+
+        // assert text or remaining stuff
+        this.assert(_.isEqual(bodyData, content),
+            'expected response body to equal #{exp} but got #{act}',
+            'expected response body to not equal #{exp}',
+            content, bodyData);
+
+    });
+
     // @todo add tests for:
     // 1. request and response content type
     // 2. response encoding

--- a/lib/sandbox/chai-postman.js
+++ b/lib/sandbox/chai-postman.js
@@ -16,7 +16,7 @@ var sdk = require('postman-collection'),
     },
 
     statusCodeReasons = {
-        ok: 200,
+        // ok: 200, // cannot add 'ok' directly since it violates underlying 'ok' property
         accepted: 202,
         withoutContent: 204, // @todo add 1223 status code
         badRequest: 400,
@@ -126,6 +126,27 @@ module.exports = function (chai) {
         });
     });
 
+    // handle ok status code reason separately
+    Assertion.addProperty('ok', function () {
+        if (!sdk.Response.isResponse(this._obj)) { // if asserted object is not response, use underlying `ok`
+            this.assert(chai.flag(this, 'object'),
+                'expected #{this} to be truthy',
+                'expected #{this} to be falsy');
+            return;
+        }
+
+        new Assertion(this._obj).to.have.property('reason');
+        new Assertion(this._obj.reason).to.be.a('function');
+
+        var wantedReason = String(reason).toUpperCase(),
+            actualReason = String(this._obj.reason()).toUpperCase();
+
+        this.assert(actualReason === wantedReason,
+            'expected response to have status reason #{exp} but got #{act}',
+            'expected response to not have status reason #{act}',
+            wantedReason, actualReason);
+    });
+
     Assertion.addMethod('status', function (codeOrReason) {
         new Assertion(this._obj).to.be.postmanResponse;
 
@@ -171,7 +192,7 @@ module.exports = function (chai) {
     Assertion.addProperty('withBody', function () {
         new Assertion(this._obj).to.be.postmanResponse;
         new Assertion(this._obj).to.have.property('text');
-        new Assertion(this._obj.json).to.be.a('function');
+        new Assertion(this._obj.text).to.be.a('function');
 
         var bodyText = this._obj.text();
 

--- a/lib/sandbox/chai-postman.js
+++ b/lib/sandbox/chai-postman.js
@@ -180,7 +180,7 @@ module.exports = function (chai) {
             'expected response to not have content in body');
     });
 
-    Assertion.addProperty('jsonBody', function () {
+    Assertion.addProperty('json', function () {
         new Assertion(this._obj).to.be.postmanResponse;
         new Assertion(this._obj).to.have.property('json');
         new Assertion(this._obj.json).to.be.a('function');

--- a/lib/sandbox/execute.js
+++ b/lib/sandbox/execute.js
@@ -89,6 +89,13 @@ module.exports = function (bridge, glob) {
         scope.exec(code, function (err) {
             // fire extra execution error event
             if (err) {
+                // fire assertion event in case the root error is an assertion. be careful not to trigger infinite loop
+                // @todo possibly move abort/stop on error here?
+                (err.name === 'AssertionError') &&
+                    scope._imports.pm.test(execution.target + ' execution failed', function () {
+                        throw err; // throw error so that normal assertion events are triggered
+                    });
+
                 bridge.dispatch(EXECUTION_ERROR_EVENT_BASE + id, cursor, err);
                 bridge.dispatch(EXECUTION_ERROR_EVENT, cursor, err);
             }

--- a/lib/sandbox/execute.js
+++ b/lib/sandbox/execute.js
@@ -89,13 +89,6 @@ module.exports = function (bridge, glob) {
         scope.exec(code, function (err) {
             // fire extra execution error event
             if (err) {
-                // fire assertion event in case the root error is an assertion. be careful not to trigger infinite loop
-                // @todo possibly move abort/stop on error here?
-                (err.name === 'AssertionError') &&
-                    scope._imports.pm.test(execution.target + ' execution failed', function () {
-                        throw err; // throw error so that normal assertion events are triggered
-                    });
-
                 bridge.dispatch(EXECUTION_ERROR_EVENT_BASE + id, cursor, err);
                 bridge.dispatch(EXECUTION_ERROR_EVENT, cursor, err);
             }

--- a/lib/sandbox/execution.js
+++ b/lib/sandbox/execution.js
@@ -28,12 +28,15 @@ Execution = function (id, event, context, options) {
     this.cursor = _.isObject(options.cursor) ? options.cursor : {};
 
     this.data = _.get(context, PROPERTY.DATA, {});
-    this.cookies = _.get(context, PROPERTY.COOKIES, []);
 
     this.environment = sdk.VariableScope.isVariableScope(context.environment) ?
         context.environment : new sdk.VariableScope(context.environment);
     this.globals = sdk.VariableScope.isVariableScope(context.globals) ?
         context.globals : new sdk.VariableScope(context.globals);
+
+    if (_.has(context, PROPERTY.COOKIES)) {
+        this.cookies = new sdk.PropertyList(sdk.Cookie, null, context.cookies);
+    }
 
     if (TARGETS_WITH_REQUEST[this.target] || _.has(context, PROPERTY.REQUEST)) {
         this.request = sdk.Request.isRequest(context.request) ? context.request : new sdk.Request(context.request);

--- a/lib/sandbox/execution.js
+++ b/lib/sandbox/execution.js
@@ -28,15 +28,12 @@ Execution = function (id, event, context, options) {
     this.cursor = _.isObject(options.cursor) ? options.cursor : {};
 
     this.data = _.get(context, PROPERTY.DATA, {});
+    this.cookies = new sdk.PropertyList(sdk.Cookie, null, context.cookies);
 
     this.environment = sdk.VariableScope.isVariableScope(context.environment) ?
         context.environment : new sdk.VariableScope(context.environment);
     this.globals = sdk.VariableScope.isVariableScope(context.globals) ?
         context.globals : new sdk.VariableScope(context.globals);
-
-    if (_.has(context, PROPERTY.COOKIES)) {
-        this.cookies = new sdk.PropertyList(sdk.Cookie, null, context.cookies);
-    }
 
     if (TARGETS_WITH_REQUEST[this.target] || _.has(context, PROPERTY.REQUEST)) {
         this.request = sdk.Request.isRequest(context.request) ? context.request : new sdk.Request(context.request);

--- a/lib/sandbox/execution.js
+++ b/lib/sandbox/execution.js
@@ -58,7 +58,24 @@ _.assign(Execution.prototype, {
                 (value[name] === undefined) && (value[name] = false);
             });
 
-            return _.isFunction(value && value.toJSON) ? value.toJSON() : value;
+            // if there is no specific json serialiser, return the raw value
+            if (!_.isFunction(value && value.toJSON)) {
+                return value;
+            }
+
+            var json,
+                tmp;
+
+            // remove assertion during json export (avoids circular object issues with chai)
+            if ((prop === PROPERTY.REQUEST || prop === PROPERTY.RESPONSE) && _.has(value, 'to')) {
+                tmp = value.to;
+                delete value.to;
+                json = value.toJSON();
+                value.to = tmp;
+                return json;
+            }
+
+            return value.toJSON();
         });
     }
 });

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -84,6 +84,21 @@ Postman = function Postman (bridge, execution) {
         }
     });
 
+    // add skipping ability to test
+    this.test.skip = function (name) {
+        var eventArgs = {
+            name: name,
+            skipped: true,
+            passed: true,
+            error: null,
+            index: ++assertionIndex // increment the assertion counter (do it before asserting)
+        };
+
+        // trigger the assertion events with skips
+        bridge.dispatch(assertionEventName, execution.cursor, eventArgs);
+        bridge.dispatch(EXECUTION_ASSERTION_EVENT, execution.cursor, eventArgs);
+    };
+
     // add response assertions
     if (this.response) {
         this.response.to = chai.expect(this.response).to;

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -2,6 +2,9 @@ var FUNCTION = 'function',
     EXECUTION_ASSERTION_EVENT = 'execution.assertion',
     EXECUTION_ASSERTION_EVENT_BASE = 'execution.assertion.',
 
+    chai = require('chai'),
+    chaiPostman = require('./chai-postman'),
+
     /**
      * Use this function to assign readonly properties to an object
      * @param {Object} obj
@@ -80,10 +83,22 @@ Postman = function Postman (bridge, execution) {
             return this; // make it chainable
         }
     });
+
+    // add response assertions
+    if (this.response) {
+        this.response.to = chai.expect(this.response).to;
+    }
+    // add request assertions
+    if (this.request) {
+        this.request.to = chai.expect(this.request).to;
+    }
 };
 
 // expose chai assertion library via prototype
-Postman.prototype.expect = require('chai').expect;
+Postman.prototype.expect = chai.expect;
+
+// make chai use postman extension
+chai.use(chaiPostman);
 
 // export
 module.exports = Postman;

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -58,6 +58,11 @@ Postman = function Postman (bridge, execution) {
         environment: execution.environment,
 
         /**
+         * @type {Object}
+         */
+        data: execution.data,
+
+        /**
          * @type {Request}
          */
         request: execution.request,

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -68,6 +68,11 @@ Postman = function Postman (bridge, execution) {
         response: execution.response,
 
         /**
+         * @type {CookieList}
+         */
+        cookies: execution.cookies,
+
+        /**
          * @param  {String} name
          * @param  {Function} assert
          * @chainable

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -23,6 +23,8 @@ var FUNCTION = 'function',
                 Object.defineProperty(obj, prop, config);
             }
         }
+
+        return obj; // chainable
     },
 
     Postman;
@@ -32,6 +34,19 @@ Postman = function Postman (bridge, execution) {
         assertionEventName = EXECUTION_ASSERTION_EVENT_BASE + execution.id;
 
     _assignDefinedReadonly(this, /** @lends Postman.prototype */ {
+        /**
+         * Contains information pertaining to the script execution
+         *
+         * @type {Object}
+         */
+        info: _assignDefinedReadonly({}, {
+            eventName: execution.target,
+            iteration: execution.cursor.iteration,
+            iterationCount: execution.cursor.cycles,
+            requestName: execution.legacy._itemName,
+            requestId: execution.legacy._itemId
+        }),
+
         /**
          * @type {VariableScope}
          */

--- a/lib/sandbox/postman-legacy-interface.js
+++ b/lib/sandbox/postman-legacy-interface.js
@@ -177,14 +177,10 @@ _.assign(PostmanLegacyInterface.prototype, /** PostmanLegacyInterface.prototype 
  * @extends {PostmanLegacyInterface}
  * @param {Object} options
  */
-PostmanLegacyTestInterface = function (execution) {
-    PostmanLegacyInterface.apply(this, arguments);
-
-    this.__cookies = {};
-    _.each(execution.cookies, function (cookie) {
-        _.isString(cookie && cookie.name) && (this.__cookies[cookie.name.toLowerCase()] = cookie);
-    }.bind(this));
+PostmanLegacyTestInterface = function () {
+    PostmanLegacyInterface.apply(this, arguments); // call super
 };
+
 inherits(PostmanLegacyTestInterface, PostmanLegacyInterface);
 
 _.assign(PostmanLegacyTestInterface.prototype, /** PostmanLegacyTestInterface.prototype */ {
@@ -193,7 +189,7 @@ _.assign(PostmanLegacyTestInterface.prototype, /** PostmanLegacyTestInterface.pr
      * @returns {Object}
      */
     getResponseCookie: function (cookieName) {
-        return _.isString(cookieName) ? this.__cookies[cookieName.toLowerCase()] : undefined;
+        return this.__execution.cookies ? this.__execution.cookies.one(String(cookieName)) : undefined;
     },
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-sandbox",
-  "version": "2.1.0",
+  "version": "2.1.1-beta.1",
   "description": "Sandbox for Postman Scripts to run in NodeJS or Chrome",
   "main": "index.js",
   "directories": {
@@ -67,7 +67,7 @@
     "nsp": "2.6.3",
     "packity": "0.3.2",
     "parse-gitignore": "0.3.1",
-    "postman-collection": "1.1.1-beta.2",
+    "postman-collection": "1.1.1-beta.3",
     "recursive-readdir": "^2.1.0",
     "shelljs": "0.7.7",
     "tv4": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-sandbox",
-  "version": "2.1.1-beta.1",
+  "version": "2.1.1-beta.2",
   "description": "Sandbox for Postman Scripts to run in NodeJS or Chrome",
   "main": "index.js",
   "directories": {

--- a/test/unit/sandbox-libraries/chai-postman.test.js
+++ b/test/unit/sandbox-libraries/chai-postman.test.js
@@ -284,7 +284,7 @@ describe('sandbox library - chai-postman', function () {
                         body: '{"hello": "world"}'
                     });
 
-                    pm.expect(response).to.be.jsonBody;
+                    pm.expect(response).to.be.json;
                 `, done);
             });
 
@@ -295,7 +295,7 @@ describe('sandbox library - chai-postman', function () {
                         body: 'undefined'
                     });
 
-                    pm.expect(response).to.be.jsonBody;
+                    pm.expect(response).to.be.json;
                 `, function (err) {
                     expect(err).be.ok();
                     expect(err).have.property('name', 'AssertionError');

--- a/test/unit/sandbox-libraries/chai-postman.test.js
+++ b/test/unit/sandbox-libraries/chai-postman.test.js
@@ -1,0 +1,236 @@
+describe('sandbox library - chai-postman', function () {
+    this.timeout(1000 * 60);
+    var Sandbox = require('../../../'),
+        context;
+
+    beforeEach(function (done) {
+        Sandbox.createContext(function (err, ctx) {
+            context = ctx;
+            done(err);
+        });
+    });
+
+    afterEach(function () {
+        context.dispose();
+        context = null;
+    });
+
+    describe('response assertion', function () {
+        describe('status code class', function () {
+            it('should be able to assert standard status classes', function (done) {
+                context.execute(`
+                    var Response = require('postman-collection').Response;
+
+                    pm.expect(new Response({code: 102})).to.have.statusCodeClass(1);
+                    pm.expect(new Response({code: 202})).to.have.statusCodeClass(2);
+                    pm.expect(new Response({code: 302})).to.have.statusCodeClass(3);
+                    pm.expect(new Response({code: 402})).to.have.statusCodeClass(4);
+                    pm.expect(new Response({code: 502})).to.have.statusCodeClass(5);
+                `, done);
+            });
+
+            it('should have properties set for common status code classes', function (done) {
+                context.execute(`
+                    var Response = require('postman-collection').Response;
+
+                    pm.expect(new Response({code: 101})).to.be.info;
+                    pm.expect(new Response({code: 201})).to.be.success;
+                    pm.expect(new Response({code: 301})).to.be.redirection;
+                    pm.expect(new Response({code: 401})).to.be.clientError;
+                    pm.expect(new Response({code: 501})).to.be.serverError;
+
+                    pm.expect(new Response({code: 501})).to.be.error;
+                    pm.expect(new Response({code: 401})).to.be.error;
+                `, done);
+            });
+
+            // @todo: add more of such failing assertions, one for each 5 classes
+            it('should be able to assert failing class "info"', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200
+                    });
+
+                    pm.expect(response).to.have.statusCodeClass(1);
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message', 'expected response code to be 1XX but found 200');
+                    done();
+                });
+            });
+        });
+
+        describe('status code', function () {
+            it('should be able to assert failing code 404', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 404
+                    });
+
+                    pm.expect(response).to.not.have.statusCode(404);
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message', 'expected response to not have status code 404');
+                    done();
+                });
+            });
+        });
+
+        describe('status code reason', function () {
+            it('should be able to verify status reason', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200
+                    });
+
+                    pm.expect(response).to.have.statusReason('Not Found');
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message',
+                        'expected response to have status reason \'Not Found\' but got \'OK\'');
+                    done();
+                });
+            });
+        });
+
+        describe('polymorphic .status', function () {
+            it('should be able to verify status reason', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200
+                    });
+
+                    pm.expect(response).to.have.status('Not Found');
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message',
+                        'expected response to have status reason \'Not Found\' but got \'OK\'');
+                    done();
+                });
+            });
+
+            it('should be able to assert failing code 404', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 404
+                    });
+
+                    pm.expect(response).to.not.have.status(404);
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message', 'expected response to not have status code 404');
+                    done();
+                });
+            });
+        });
+
+        describe('headers', function () {
+            it('should be able to determine existence of a key', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200,
+                        header: 'oneHeader:oneValue'
+                    });
+
+                    pm.expect(response).to.have.header('oneHeader');
+                    pm.expect(response).to.have.header('oneHeader', 'oneValue');
+                `, done);
+            });
+
+            it('should be able to determine absence of a key', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200,
+                        header: 'oneHeader:oneValue'
+                    });
+
+                    pm.expect(response).not.to.have.header('oneHeader');
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message',
+                        'expected response to not have header with key \'oneHeader\'');
+                    done();
+                });
+            });
+
+            it('should be able to determine mismatch of a key\'s value', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200,
+                        header: 'oneHeader:oneValue'
+                    });
+
+                    pm.expect(response).to.have.header('oneHeader', 'noValue');
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message',
+                        'expected \'oneHeader\' response header to be \'noValue\' but got \'oneValue\'');
+                    done();
+                });
+            });
+        });
+
+        describe('body', function () {
+            it('must have a property to assert valid text body', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200,
+                        body: 'this is a body'
+                    });
+
+                    pm.expect(response).to.be.withBody;
+                `, done);
+            });
+
+            it('must be able to assert invalid text body', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200
+                    });
+
+                    pm.expect(response).to.be.withBody;
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message', 'expected response to have content in body');
+                    done();
+                });
+            });
+
+            it('must have a property to assert valid json', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200,
+                        body: '{"hello": "world"}'
+                    });
+
+                    pm.expect(response).to.be.jsonBody;
+                `, done);
+            });
+
+            it('must be able to assert invalid json', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200,
+                        body: 'undefined'
+                    });
+
+                    pm.expect(response).to.be.jsonBody;
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message',
+                        'expected response body to be a valid json but got error Unexpected token \'u\' at 1:1');
+                    done();
+                });
+            });
+        });
+    });
+});

--- a/test/unit/sandbox-libraries/chai-postman.test.js
+++ b/test/unit/sandbox-libraries/chai-postman.test.js
@@ -304,6 +304,55 @@ describe('sandbox library - chai-postman', function () {
                     done();
                 });
             });
+
+            it('must be able to ensure negation of body exists using .body function', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200,
+                        body: 'undefined'
+                    });
+
+                    pm.expect(response).to.not.have.body();
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message', 'expected response to not have content in body');
+                    done();
+                });
+            });
+
+            it('must be able to ensure body matches a string negation', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200,
+                        body: 'undefined'
+                    });
+
+                    pm.expect(response).to.not.have.body('undefined');
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message', 'expected response body to not equal \'undefined\'');
+                    done();
+                });
+            });
+
+            it('must be able to ensure body matches a regexp negation', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200,
+                        body: 'undefined'
+                    });
+
+                    pm.expect(response).to.not.have.body(/def/);
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message',
+                        'expected response body text \'undefined\' to not match /def/');
+                    done();
+                });
+            });
         });
     });
 });

--- a/test/unit/sandbox-libraries/chai-postman.test.js
+++ b/test/unit/sandbox-libraries/chai-postman.test.js
@@ -353,6 +353,73 @@ describe('sandbox library - chai-postman', function () {
                     done();
                 });
             });
+
+            it('must be able to ensure body contains json using .json', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200,
+                        body: 'undefined'
+                    });
+
+                    pm.expect(response).to.have.jsonBody();
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message',
+                        'expected response body to be a valid json but got error Unexpected token \'u\' at 1:1');
+                    done();
+                });
+            });
+
+            it('must be able to ensure body does not contain json using .json negation', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200,
+                        body: '{"prop":[{"value":{"oh":"wow"}}]}'
+                    });
+
+                    pm.expect(response).to.not.have.jsonBody();
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message', 'expected response body not to be a valid json');
+                    done();
+                });
+            });
+
+            it('must be able to ensure body contain json data in path', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200,
+                        body: '{"prop":[{"value":{"oh":"wow"}}]}'
+                    });
+
+                    pm.expect(response).to.not.have.jsonBody('prop[0]');
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message',
+                        'expected { prop: [ { value: [Object] } ] } in response to not contain property \'prop[0]\'');
+                    done();
+                });
+            });
+
+            it('must be able to ensure body contain a particular json value in path', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200,
+                        body: '{"prop":[{"value":{"oh":"wow"}}]}'
+                    });
+
+                    pm.expect(response).to.have.jsonBody('prop[0].value', {v:1});
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message',
+                        'expected response body json at "prop[0].value" to contain { v: 1 } but got { oh: \'wow\' }');
+                    done();
+                });
+            });
         });
     });
 });

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -188,7 +188,9 @@ describe('sandbox library - pm api', function () {
             context.execute(`
                 var assert = require('assert'),
                     Response = require('postman-collection').Response;
-                assert.strictEqual(Response.isResponse(pm.response), true);
+
+                assert.strictEqual(Response.isResponse(pm.response), true, 'pm.response should be sdk');
+                assert.strictEqual(pm.response.code, 200, 'code should match');
             `, {
                 context: {
                     response: {
@@ -254,6 +256,31 @@ describe('sandbox library - pm api', function () {
                 expect(err).have.property('message', 'expected [Error] not to be an error');
                 done();
             });
+        });
+
+        it('must pre-assert response', function (done) {
+            context.execute(`
+                pm.expect(pm.response).to.have.property('to');
+                pm.expect(pm.response.to).be.an('object');
+
+                // run a test as well ;-)
+                pm.response.to.be.ok;
+            `, {
+                context: {
+                    response: {code: 200}
+                }
+            }, done);
+        });
+
+        it('must pre-assert request', function (done) {
+            context.execute(`
+                pm.expect(pm.request).to.have.property('to');
+                pm.expect(pm.request.to).be.an('object');
+            `, {
+                context: {
+                    request: 'https://postman-echo.com/'
+                }
+            }, done);
         });
     });
 });

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -41,6 +41,33 @@ describe('sandbox library - pm api', function () {
         `, done);
     });
 
+    describe('info', function () {
+        it('must have relevant information', function (done) {
+            context.execute({
+                listen: 'test',
+                script: `
+                    var assert = require('assert');
+
+                    assert.strictEqual(pm.info.eventName, 'test', 'event name must be test');
+                    assert.strictEqual(pm.info.iteration, 2, 'iteration should be 2');
+                    assert.strictEqual(pm.info.iterationCount, 3, 'iteration total should be 3');
+                    assert.strictEqual(pm.info.requestName, 'request-name', 'requestName should be accurate');
+                    assert.strictEqual(pm.info.requestId, 'request-id', 'requestId should be accurate');
+                `
+            }, {
+                cursor: {
+                    iteration: 2,
+                    cycles: 3
+                },
+                legacy: {
+                    _itemName: 'request-name',
+                    _itemId: 'request-id'
+                }
+
+            }, done);
+        });
+    });
+
     describe('globals', function () {
         it('must be defined as VariableScope', function (done) {
             context.execute(`

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -23,7 +23,7 @@ describe('sandbox library - pm api', function () {
         context;
 
     beforeEach(function (done) {
-        Sandbox.createContext(function (err, ctx) {
+        Sandbox.createContext({debug: true}, function (err, ctx) {
             context = ctx;
             done(err);
         });
@@ -262,6 +262,55 @@ describe('sandbox library - pm api', function () {
                             data: [123, 34, 102, 111, 111, 34, 58, 32, 34, 98, 97, 114, 34, 125]
                         }
                     }
+                }
+            }, done);
+        });
+    });
+
+    describe('cookies', function () {
+        it('must be available', function (done) {
+            context.execute(`
+                var assert = require('assert');
+                assert.strictEqual(typeof pm.cookies, 'object', 'cookies must be defined');
+            `, {
+                context: {
+                    cookies: []
+                }
+            }, done);
+        });
+
+        it('must convert context cookie array to list', function (done) {
+            context.execute(`
+                var assert = require('assert');
+                assert.strictEqual(pm.cookies.count(), 2, 'two cookies must be present');
+            `, {
+                context: {
+                    cookies: [{
+                        name: 'cookie1',
+                        value: 'onevalue',
+                        httpOnly: true
+                    }, {
+                        name: 'cookie2',
+                        value: 'anothervalue'
+                    }]
+                }
+            }, done);
+        });
+
+        it('must return value of one cookie', function (done) {
+            context.execute(`
+                var assert = require('assert');
+                assert.strictEqual(pm.cookies.one('cookie2').value, 'anothervalue', 'value must be defined');
+            `, {
+                context: {
+                    cookies: [{
+                        name: 'cookie1',
+                        value: 'onevalue',
+                        httpOnly: true
+                    }, {
+                        name: 'cookie2',
+                        value: 'anothervalue'
+                    }]
                 }
             }, done);
         });


### PR DESCRIPTION
also adds

- fix for failing assertion events in main scripts not being bubbled (when not put in pm.test)
- ability to do pm.test.skip
- pm.cookies is a real PropertyList now