### PR TITLE
Added responseSize and responseTime assertions

### DIFF
--- a/lib/sandbox/chai-postman.js
+++ b/lib/sandbox/chai-postman.js
@@ -316,10 +316,49 @@ module.exports = function (chai) {
 
     });
 
+    Assertion.addChainableMethod('responseTime', function (value) {
+        var time = chai.util.flag(this, 'number');
+
+        this.assert(_.isNumber(time),
+            'expected response to have a valid response time but got #{act}',
+            'expected response to not have a valid response time but got #{act}', null, time);
+
+        arguments.length && this.assert(_.isEqual(time, value),
+            'expected response to have a valid response time but got #{act}',
+            'expected response to not have a valid response time but got #{act}', null, time);
+    }, function () {
+        new Assertion(this._obj).to.be.postmanResponse;
+        new Assertion(this._obj).to.have.property('responseTime');
+
+        chai.util.flag(this, 'number', this._obj.responseTime);
+        this._obj = _.get(this._obj, 'responseTime'); // @todo: do this the right way adhering to chai standards
+    });
+
+    Assertion.addChainableMethod('responseSize', function (value) {
+        var size = chai.util.flag(this, 'number');
+
+        this.assert(_.isNumber(size),
+            'expected response to have a valid response size but got #{act}',
+            'expected response to not have a valid response size but got #{act}', null, size);
+
+        arguments.length && this.assert(_.isEqual(size, value),
+            'expected response size to equal #{act} but got #{exp}',
+            'expected response size to not equal #{act} but got #{exp}', value, size);
+    }, function () {
+        new Assertion(this._obj).to.be.postmanResponse;
+        new Assertion(this._obj).to.have.property('size');
+        new Assertion(this._obj.size).to.be.a('function');
+
+        var size = this._obj.size(),
+            total = (size.header || 0) + (size.body || 0);
+
+        chai.util.flag(this, 'number', total);
+        this._obj = total; // @todo: do this the right way adhering to chai standards
+    });
+
     // @todo add tests for:
     // 1. request and response content type
     // 2. response encoding
-    // 3. response time
     // 4. response size
     // 5. cookies
     // 6. assert on http/https

--- a/test/unit/sandbox-libraries/chai-postman.test.js
+++ b/test/unit/sandbox-libraries/chai-postman.test.js
@@ -421,5 +421,65 @@ describe('sandbox library - chai-postman', function () {
                 });
             });
         });
+
+        describe('response time', function () {
+            it('should have a way to be asserted for presence', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        responseTime: 200
+                    });
+
+                    pm.expect(response).to.have.responseTime();
+                `, done);
+            });
+
+            it('should have a way to be asserted for absence', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        responseTime: NaN
+                    });
+                    pm.expect(response).to.have.responseTime();
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message',
+                        'expected { Object (id, _details, ...) } to have a property \'responseTime\'');
+                    done();
+                });
+            });
+
+            it('should allow numeric assertions to check less-than', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        responseTime: 200
+                    });
+                    pm.expect(response).to.have.responseTime.below(100);
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message', 'expected 200 to be below 100');
+                    done();
+                });
+            });
+        });
+
+        describe('response size', function () {
+            it('must be able assert below a figure', function (done) {
+                context.execute(`
+                    var response = new (require('postman-collection').Response)({
+                        code: 200,
+                        header: 'oneHeader:oneValue',
+                        stream: new Buffer('hello there')
+                    });
+
+                    pm.expect(response).to.have.responseSize.below(50);
+                `, function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('name', 'AssertionError');
+                    expect(err).have.property('message', 'expected 51 to be below 50');
+                    done();
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
This is also an experiment with chainable assertions.

```
pm.response.to.have.responseTime(200); // in ms
pm.response.to.have.responseTime.below(200);
pm.response.to.have.responseTime.above(200);
```

```
pm.response.to.have.responseSize(200); // in bytes
pm.response.to.have.responseSize.below(200);
pm.response.to.have.responseSize.above(200);
```