### PR TITLE
pmapi: test runner is separated into a decorator module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Unreleased
 * Support for timers inside sandbox (not in browser)
+* Fixed bug where `pm.test` called without an assertion function would not trigger assertion event
 
 #### 2.1.5 (May 16 2017)
 * Fixed bug that caused an invalid version of Collection SDK to be cached on prepublish

--- a/lib/sandbox/pmapi-setup-runner.js
+++ b/lib/sandbox/pmapi-setup-runner.js
@@ -1,0 +1,46 @@
+var FUNCTION = 'function';
+
+module.exports = function (pm, onAssertion) {
+    var assertionIndex = 0;
+
+    /**
+     * @param  {String} name
+     * @param  {Function} assert
+     * @chainable
+     */
+    pm.test = function (name, assert) {
+
+        if (typeof assert !== FUNCTION) {
+            return;
+        }
+
+        var eventArgs = {
+            name: name,
+            passed: true,
+            error: null,
+            index: assertionIndex++ // increment the assertion counter (do it before asserting)
+        };
+
+        try { (typeof assert === FUNCTION) && assert(); }
+        catch (e) {
+            eventArgs.error = e;
+            eventArgs.passed = false;
+        }
+
+        onAssertion(eventArgs);
+        return pm; // make it chainable
+    };
+
+    pm.test.skip = function (name) {
+        // trigger the assertion events with skips
+        onAssertion({
+            name: name,
+            skipped: true,
+            passed: true,
+            error: null,
+            index: ++assertionIndex // increment the assertion counter (do it before asserting)
+        });
+
+        return pm; // chainable
+    };
+};

--- a/lib/sandbox/pmapi-setup-runner.js
+++ b/lib/sandbox/pmapi-setup-runner.js
@@ -1,7 +1,16 @@
 var FUNCTION = 'function';
 
 module.exports = function (pm, onAssertion) {
-    var assertionIndex = 0;
+    var assertionIndex = 0,
+        getAssertionObject = function (name, skipped) {
+            return {
+                name: String(name),
+                skipped: Boolean(skipped),
+                passed: true,
+                error: null,
+                index: assertionIndex++ // increment the assertion counter (do it before asserting)
+            };
+        };
 
     /**
      * @param  {String} name
@@ -9,17 +18,7 @@ module.exports = function (pm, onAssertion) {
      * @chainable
      */
     pm.test = function (name, assert) {
-
-        if (typeof assert !== FUNCTION) {
-            return;
-        }
-
-        var eventArgs = {
-            name: name,
-            passed: true,
-            error: null,
-            index: assertionIndex++ // increment the assertion counter (do it before asserting)
-        };
+        var eventArgs = getAssertionObject(name, false);
 
         try { (typeof assert === FUNCTION) && assert(); }
         catch (e) {
@@ -33,14 +32,7 @@ module.exports = function (pm, onAssertion) {
 
     pm.test.skip = function (name) {
         // trigger the assertion events with skips
-        onAssertion({
-            name: name,
-            skipped: true,
-            passed: true,
-            error: null,
-            index: ++assertionIndex // increment the assertion counter (do it before asserting)
-        });
-
+        onAssertion(getAssertionObject(name, true));
         return pm; // chainable
     };
 };

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -1,5 +1,4 @@
-var FUNCTION = 'function',
-    EXECUTION_ASSERTION_EVENT = 'execution.assertion',
+var EXECUTION_ASSERTION_EVENT = 'execution.assertion',
     EXECUTION_ASSERTION_EVENT_BASE = 'execution.assertion.',
 
     VariableScope = require('postman-collection').VariableScope,
@@ -28,11 +27,17 @@ var FUNCTION = 'function',
         return obj; // chainable
     },
 
+    setupTestRunner = require('./pmapi-setup-runner'),
     Postman;
 
+/**
+ * @constructor
+ *
+ * @param {EventEmitter} bridge
+ * @param {Execution} execution
+ */
 Postman = function Postman (bridge, execution) {
-    var assertionIndex = 0,
-        assertionEventName = EXECUTION_ASSERTION_EVENT_BASE + execution.id,
+    var assertionEventName = EXECUTION_ASSERTION_EVENT_BASE + execution.id, // we keep this prepared for repeat use
         iterationData;
 
     // @todo - ensure runtime passes data in a scope format
@@ -86,54 +91,14 @@ Postman = function Postman (bridge, execution) {
         /**
          * @type {CookieList}
          */
-        cookies: execution.cookies,
-
-        /**
-         * @param  {String} name
-         * @param  {Function} assert
-         * @chainable
-         */
-        test: function (name, assert) {
-
-            if (typeof assert !== FUNCTION) {
-                return;
-            }
-
-            var eventArgs = {
-                name: name,
-                passed: true,
-                error: null,
-                index: assertionIndex++ // increment the assertion counter (do it before asserting)
-            };
-
-            try { assert(); }
-            catch (e) {
-                eventArgs.error = e;
-                eventArgs.passed = false;
-            }
-
-            // trigger the assertion events
-            bridge.dispatch(assertionEventName, execution.cursor, eventArgs);
-            bridge.dispatch(EXECUTION_ASSERTION_EVENT, execution.cursor, eventArgs);
-
-            return this; // make it chainable
-        }
+        cookies: execution.cookies
     });
 
-    // add skipping ability to test
-    this.test.skip = function (name) {
-        var eventArgs = {
-            name: name,
-            skipped: true,
-            passed: true,
-            error: null,
-            index: ++assertionIndex // increment the assertion counter (do it before asserting)
-        };
-
-        // trigger the assertion events with skips
-        bridge.dispatch(assertionEventName, execution.cursor, eventArgs);
-        bridge.dispatch(EXECUTION_ASSERTION_EVENT, execution.cursor, eventArgs);
-    };
+    // extend pm api with test runner abilities
+    setupTestRunner(this, function (assertion) {
+        bridge.dispatch(assertionEventName, execution.cursor, assertion);
+        bridge.dispatch(EXECUTION_ASSERTION_EVENT, execution.cursor, assertion);
+    });
 
     // add response assertions
     if (this.response) {
@@ -143,6 +108,8 @@ Postman = function Postman (bridge, execution) {
     if (this.request) {
         this.request.to = chai.expect(this.request).to;
     }
+
+    iterationData = null; // precautionary
 };
 
 // expose chai assertion library via prototype


### PR DESCRIPTION
- allows better organisation
- cleaner code for having a common assertion handler for test and skip
- minor bug fix where assertion was not triggered if assertion function was not sent to pm.test