### PR TITLE
async: handle timers on context dispose

### DIFF
--- a/lib/sandbox/execute.js
+++ b/lib/sandbox/execute.js
@@ -7,6 +7,7 @@ var _ = require('lodash'),
     PostmanTimers = require('./timers'),
     legacy = require('./postman-legacy-interface'),
 
+    DISCONNECT_EVENT = 'disconnect',
     EXECUTION_RESULT_EVENT_BASE = 'execution.result.',
     EXECUTION_ERROR_EVENT = 'execution.error',
     EXECUTION_ERROR_EVENT_BASE = 'execution.error.',
@@ -57,12 +58,27 @@ module.exports = function (bridge, glob) {
 
             waiting,
             timers,
+            release, // fn
             done; // fn
+
+        // create a function to neatly release resources
+        release = function () {
+            if (timers) {
+                timers.seal();
+                timers.clearAll();
+            }
+            waiting && (waiting = clearTimeout(waiting));
+        };
 
         // create a function to neatly exit execution
         done = function (err) {
             waiting && (waiting = clearTimeout(waiting)); // stop any new timers from being added
-            timers && timers.seal(); // do not allow any more timers
+            bridge.off(DISCONNECT_EVENT, release); // remove listener of disconnection event
+
+            if (timers) { // do not allow any more timers
+                timers.seal();
+                timers.clearAll();
+            }
             bridge.dispatch(executionEventName, err || null, execution); // fire the execution completion event
         };
 
@@ -97,11 +113,13 @@ module.exports = function (bridge, glob) {
         // if a timeout is set, we must ensure that all pending timers are cleared and an execution timeout event is
         // trigerred.
         _.isFinite(options.timeout) && (waiting = setTimeout(function () {
-            timers.clearAll(); // if there are existing timers, clear all
-
             done(new Error('sandbox: ' +
                 (execution.return.async ? 'asynchronous' : 'synchronous') + ' script execution timeout'));
         }, options.timeout));
+
+        // hook on to the disconnect event to be able to release this scope in case
+        // it disconnects (remember to remove it when `done`.)
+        bridge.on(DISCONNECT_EVENT, release);
 
         // prepare the scope's environment variables
         scope.import({

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "inherits": "2.0.3",
     "lodash": "4.17.2",
     "uuid": "3.0.1",
-    "uvm": "1.5.0"
+    "uvm": "^1.6.0"
   },
   "devDependencies": {
     "assert": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "inherits": "2.0.3",
     "lodash": "4.17.2",
     "uuid": "3.0.1",
-    "uvm": "^1.6.0"
+    "uvm": "1.6.0"
   },
   "devDependencies": {
     "assert": "1.4.1",

--- a/test/unit/sandbox-dispose.test.js
+++ b/test/unit/sandbox-dispose.test.js
@@ -1,0 +1,54 @@
+describe('sandbox disposal', function () {
+    this.timeout(1000 * 60);
+    var Sandbox = require('../../lib');
+
+    it('must work', function (done) {
+        Sandbox.createContext({debug: false}, function (err, context) {
+            if (err) { return done(err); }
+            context.on('error', done);
+
+            var status = {
+                started: false,
+                disconnected: false,
+                misfiredTimer: false
+            };
+
+            context.on('console', function (cur, lvl, msg) {
+                switch (msg) {
+                    case 'started':
+                        status.started = true;
+
+                        setTimeout(context.dispose.bind(context), 1);
+                        setTimeout(function () {
+                            expect(status).to.have.property('started', true);
+                            expect(status).to.have.property('disconnected', true);
+                            expect(status).to.have.property('misfiredTimer', false);
+                            done();
+                        }, 100);
+                        break;
+
+                    case 'timeout':
+                        status.misfiredTimer = true;
+                        done(new Error('expected sandbox timeout to be cleared'));
+                        break;
+
+                    default:
+                        done(new Error('unexpected console communication from sandbox'));
+                }
+            });
+
+            context.execute(`
+                console.log('started');
+
+                setTimeout(function () {
+                    console.log('timeout');
+                }, 50);
+            `, {
+                timeout: 1000
+            }, function (err) {
+                status.disconnected = true;
+                expect(err).to.have.property('message', 'sandbox: execution interrupted, bridge disconnecting.');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Simple augmentation:

1. upgraded to `uvm@1.6.0` - which dispatches a `disconnect` event inside sandbox right before `context.disconnect()` is called inside `sandbox.dispose`.

2. Made changes to the `.execute`'s event listener inside sandbox to listen to the `disconnect` event (and unlisten on execution completion) to clear all pending timers when that happens.

3. There is no requirement to bubble the execution completion event in case of disconnection since that would be (a) unreliable and (b) it is already handled from outside sandbox