### PR TITLE
Cleanup timer `set/clear/clearAll` function assignments

### DIFF
--- a/lib/sandbox/timers.js
+++ b/lib/sandbox/timers.js
@@ -44,17 +44,26 @@ var /**
      */
     defaultTimers = timerFunctionNames.reduce(function (timers, name) {
         // get hold of default timer functions as available in global scope
-        var fnset = (new Function('return (typeof set' + name + // eslint-disable-line no-new-func
-                ' === "function" ? set' + name + ' : undefined);'))(),
-            fnclr = (new Function('return (typeof clear' + name + // eslint-disable-line no-new-func
-                ' === "function" ? clear' + name + ' : undefined);'))();
+        var setFnName = 'set' + name,
+            clrFnName = 'clear' + name,
+            clrAllFnName = 'clearAll' + name + 's',
+            fnset = (new Function('return (typeof ' + setFnName + ' === "function" ? ' + // eslint-disable-line no-new-func
+                setFnName + ' : undefined);'))(),
+            fnclr = (new Function('return (typeof ' + clrFnName + ' === "function" ? ' + // eslint-disable-line no-new-func
+                clrFnName + ' : undefined);'))(),
+            fnclrAll = (new Function('return (typeof ' + clrAllFnName + ' === "function" ? ' + // eslint-disable-line no-new-func
+                clrAllFnName + ' : undefined);'))();
 
         if (typeof fnset === 'function') {
-            timers[('set' + name)] = fnset;
+            timers[setFnName] = fnset;
         }
 
         if (typeof fnclr === 'function') {
-            timers[('clear' + name)] = fnclr;
+            timers[clrFnName] = fnclr;
+        }
+
+        if (typeof clrAllFnName === 'function') {
+            timers[clrAllFnName] = fnclrAll;
         }
 
         return timers;
@@ -138,10 +147,13 @@ Timerz = function Timerz (delegations, onError, onAnyTimerStart, onAllTimerEnd) 
     // iterate through the timer variants and create common setter and clearer function behaviours for each of them.
     timerFunctionNames.forEach(function (name) {
         // create an accumulator for all timer references
-        var running = {};
+        var running = {},
+            setFnName = 'set' + name,
+            clrFnName = 'clear' + name,
+            clrAllFnName = 'clearAll' + name + 's';
 
         // create the setter function for the timer
-        this[('set' + name)] = function (callback) {
+        this[setFnName] = function (callback) {
             // it is pointless to proceed with setter if there is no callback to execute
             if (sealed || typeof callback !== 'function') {
                 return;
@@ -175,7 +187,7 @@ Timerz = function Timerz (delegations, onError, onAnyTimerStart, onAllTimerEnd) 
             staticTimerFunctions[name] && (wentAsync = true);
 
             // call the underlying timer function and keep a track of its irq
-            running[id] = timers[('set' + name)].apply(this, args);
+            running[id] = timers[setFnName].apply(this, args);
             args = null; // precaution
 
             // increment the counter and return the tracking ID to be used to pass on to clearXYZ function
@@ -184,7 +196,7 @@ Timerz = function Timerz (delegations, onError, onAnyTimerStart, onAllTimerEnd) 
         };
 
         // create the clear function of the timer
-        this[('clear' + name)] = function (id) {
+        this[clrFnName] = function (id) {
             var underLyingId = running[id],
                 args;
 
@@ -200,7 +212,7 @@ Timerz = function Timerz (delegations, onError, onAnyTimerStart, onAllTimerEnd) 
 
             // fire the underlying clearing function
 
-            try { timers['clear' + name].apply(dummyContext, args); }
+            try { timers[clrFnName].apply(dummyContext, args); }
             catch (e) { onError(e); }
 
             // decrement counters and call the clearing timer function
@@ -211,21 +223,21 @@ Timerz = function Timerz (delegations, onError, onAnyTimerStart, onAllTimerEnd) 
 
         // create a sugar function to clear all running timers of this category
         // @todo: decide how to handle clearing for underlying delegated timers, if they are instances of Timerz itself.
-        if (typeof timers[('clearAll' + name + 's')] === 'function') {
+        if (typeof timers[clrAllFnName] === 'function') {
             // if native timers have a function to clear all timers, then use it
-            this[('clearAll' + name + 's')] = function () {
-                timers[('clearAll' + name + 's')]();
+            this[clrAllFnName] = function () {
+                timers[clrAllFnName]();
                 Object.keys(running).forEach(function () {
                     computeTimerEvents(-1, true);
                 });
             };
         }
         else {
-            this[('clearAll' + name + 's')] = function () {
+            this[clrAllFnName] = function () {
                 Object.keys(running).forEach(function (id) {
                     computeTimerEvents(-1, true);
                     // run clear functions except for static timers
-                    timers['clear' + name](running[id]);
+                    timers[clrFnName](running[id]);
                 });
             };
         }
@@ -253,16 +265,30 @@ Timerz = function Timerz (delegations, onError, onAnyTimerStart, onAllTimerEnd) 
     };
 
     /**
+     * Bails out any future timer set functions.
+     *
      * @memberof Timerz.prototype
      */
     this.seal = function () {
         sealed = true;
     };
 
+    /**
+     * Invokes the timer error callback with given error.
+     *
+     * @param {Error} err
+     *
+     * @memberof Timerz.prototype
+     */
     this.error = function (err) {
         return onError.call(dummyContext, err);
     };
 
+    /**
+     * Clears all timer functions and seals creating new timers.
+     *
+     * @memberof Timerz.prototype
+     */
     this.terminate = function () {
         this.seal();
         this.clearAll();


### PR DESCRIPTION
1. Add `clearAll` functions to default timers
2. General cleaning in initializing timer `set/clear/clearAll` functions
3. Added docs for `seal`, `error` and `terminate` methods