### PR TITLE
Send request events per execution id

### DIFF
--- a/lib/sandbox/execute.js
+++ b/lib/sandbox/execute.js
@@ -7,7 +7,7 @@ var _ = require('lodash'),
     PostmanAPI = require('./pmapi'),
 
     EXECUTION_RESULT_EVENT_BASE = 'execution.result.',
-    EXECUTION_REQUEST_EVENT = 'execution.request',
+    EXECUTION_REQUEST_EVENT_BASE = 'execution.request.',
     EXECUTION_ERROR_EVENT = 'execution.error',
     EXECUTION_ERROR_EVENT_BASE = 'execution.error.',
     EXECUTION_ABORT_EVENT_BASE = 'execution.abort.',
@@ -46,6 +46,7 @@ module.exports = function (bridge, glob) {
         event = (new PostmanEvent(event));
 
         var executionEventName = EXECUTION_RESULT_EVENT_BASE + id,
+            executionRequestEventName = EXECUTION_REQUEST_EVENT_BASE + id,
             errorEventName = EXECUTION_ERROR_EVENT_BASE + id,
             abortEventName = EXECUTION_ABORT_EVENT_BASE + id,
             responseEventName = EXECUTION_RESPONSE_EVENT_BASE + id,
@@ -114,7 +115,7 @@ module.exports = function (bridge, glob) {
             timers,
             (new PostmanAPI(bridge, execution, function (request, callback) {
                 var eventId = timers.setEvent(callback);
-                bridge.dispatch(EXECUTION_REQUEST_EVENT, options.cursor, id, eventId, request);
+                bridge.dispatch(executionRequestEventName, options.cursor, id, eventId, request);
             })));
     });
 };

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -510,18 +510,24 @@ describe('sandbox library - pm api', function () {
             `, {context: sampleContextData}, done);
         });
 
-        it('must dispatch an `execution.request` event when called', function (done) {
-            context.on('execution.request', function (cursor, id, requestId, req) {
+        it('must dispatch an `execution.request.${id}` event when called', function (done) {
+            var executionId = '1';
+
+            context.on('execution.request.' + executionId, function (cursor, id, requestId, req) {
                 expect(req).to.have.property('url', 'https://postman-echo.com/get');
                 done();
             });
 
             context.execute(`
                 pm.sendRequest('https://postman-echo.com/get');
-            `, {context: sampleContextData}, function () {}); // eslint-disable-line no-empty-function
+            `, {
+                context: sampleContextData,
+                id: executionId
+            }, function () {}); // eslint-disable-line no-empty-function
         });
 
         it('must forward response to callback when sent from outside', function (done) {
+            var executionId = '2';
             context.on('error', done);
 
             context.on('execution.error', function (cur, err) {
@@ -536,7 +542,7 @@ describe('sandbox library - pm api', function () {
                 done();
             });
 
-            context.on('execution.request', function (cursor, id, requestId, req) {
+            context.on('execution.request.' + executionId, function (cursor, id, requestId, req) {
                 expect(req).to.have.property('url', 'https://postman-echo.com/get');
                 context.dispatch(`execution.response.${id}`, requestId, null, {
                     code: 200,
@@ -551,7 +557,10 @@ describe('sandbox library - pm api', function () {
                         pm.expect(res.json()).to.have.property('i am', 'a json');
                     });
                 });
-            `, {context: sampleContextData}, function () {}); // eslint-disable-line no-empty-function
+            `, {
+                context: sampleContextData,
+                id: executionId
+            }, function () {}); // eslint-disable-line no-empty-function
         });
     });
 });


### PR DESCRIPTION
Send request events per execution id instead of a global execution.request event