### PR TITLE
Fix bug in pm API header assertion

### DIFF
--- a/lib/sandbox/chai-postman.js
+++ b/lib/sandbox/chai-postman.js
@@ -178,9 +178,9 @@ module.exports = function (chai) {
         var ror = requestOrResponse(this._obj);
 
         this.assert(this._obj.headers.has(headerKey),
-            'expected ' + ror + ' to have header with key #{exp}',
-            'expected ' + ror + ' to not have header with key #{exp}',
-            headerKey);
+            'expected ' + ror + ' to have header with key ' + headerKey,
+            'expected ' + ror + ' to not have header with key ' + headerKey,
+            true, this._obj.headers.has(headerKey));
 
         if (arguments.length < 2) { return; } // in case no check is done on value
 


### PR DESCRIPTION
When `pm.response.to.have.header('non-existant')` is uses in a test script it crashes the test script with `Error: Invalid Chai property: _postman_propertyIsList`.

Ideally, should have failed the test and continued with the script.