### PR TITLE
Moved browserify to dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "author": "Postman Labs <help@getpostman.com> (=)",
   "license": "Apache-2.0",
   "dependencies": {
-    "browserify": "14.4.0",
     "inherits": "2.0.3",
     "lodash": "4.17.2",
     "uuid": "3.1.0",
@@ -40,6 +39,7 @@
     "async": "2.5.0",
     "atob": "2.0.3",
     "backbone": "1.3.3",
+    "browserify": "14.4.0",
     "btoa": "1.1.2",
     "buffer": "5.0.7",
     "chai": "4.1.2",


### PR DESCRIPTION
Browserify is not needed for production use since NPM pre-publish script ensures that a cache file is published. Cache file is pre-bundled and as such browserify is not needed. The need to load browserify is already put within a `try` block.