### PR TITLE
Correct chai assignment to pm.request.to and pm.response.to

### DIFF
--- a/lib/sandbox/pmapi-setup-chai.js
+++ b/lib/sandbox/pmapi-setup-chai.js
@@ -33,7 +33,5 @@ module.exports = function setupChai (self, chai) {
 
     // make chai use postman extension
     chai.use(chaiPostman(sdk, _));
-
-    return self;
 };
 

--- a/lib/sandbox/pmapi-setup-chai.js
+++ b/lib/sandbox/pmapi-setup-chai.js
@@ -1,5 +1,6 @@
 var languageChains = ['be', 'have', 'include'],
     sdk = require('postman-collection'),
+    chaiPostman = require('chai-postman'),
     _ = require('lodash'),
     responseAssertion,
     requestAssertion;
@@ -31,7 +32,7 @@ module.exports = function setupChai (self, chai) {
     }
 
     // make chai use postman extension
-    chai.use(require('chai-postman')(sdk, _));
+    chai.use(chaiPostman(sdk, _));
 
     return self;
 };

--- a/lib/sandbox/pmapi-setup-chai.js
+++ b/lib/sandbox/pmapi-setup-chai.js
@@ -1,0 +1,38 @@
+var languageChains = ['be', 'have', 'include'],
+    sdk = require('postman-collection'),
+    _ = require('lodash'),
+    responseAssertion,
+    requestAssertion;
+
+module.exports = function setupChai (self, chai) {
+    // add response assertions
+    if (self.response) {
+        // these are removed before serializing see `purse.js`
+        self.response.to = {not: {}};
+        responseAssertion = chai.expect(self.response).to;
+
+        // explicitly assigning chai methods to chai's 'to' and 'to.not'.
+        languageChains.forEach(function eachLanguageChain (value) {
+            self.response.to[value] = responseAssertion.to[value];
+            self.response.to.not[value] = responseAssertion.not[value];
+        });
+    }
+    // add request assertions
+    if (self.request) {
+        // these are removed before serializing see `purse.js`
+        self.request.to = {not: {}};
+        requestAssertion = chai.expect(self.request).to;
+
+        // explicitly assigning chai methods to chai's 'to' and 'to.not'.
+        languageChains.forEach(function eachLanguageChain (value) {
+            self.request.to[value] = requestAssertion[value];
+            self.request.to.not[value] = requestAssertion.not[value];
+        });
+    }
+
+    // make chai use postman extension
+    chai.use(require('chai-postman')(sdk, _));
+
+    return self;
+};
+

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -112,6 +112,7 @@ Postman = function Postman (bridge, execution, onRequest) {
         bridge.dispatch(EXECUTION_ASSERTION_EVENT, execution.cursor, [assertion]);
     });
 
+    // Adding chai language chains to pm.request.to and pm.response.to, initialising chai-postman plugin.
     self = setupChai(self, chai);
 
     /**

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -113,7 +113,7 @@ Postman = function Postman (bridge, execution, onRequest) {
     });
 
     // Adding chai language chains to pm.request.to and pm.response.to, initialising chai-postman plugin.
-    self = setupChai(self, chai);
+    setupChai(self, chai);
 
     /**
      * Allows one to send request from script.

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -43,7 +43,9 @@ var EXECUTION_ASSERTION_EVENT = 'execution.assertion',
 Postman = function Postman (bridge, execution, onRequest) {
     var assertionEventName = EXECUTION_ASSERTION_EVENT_BASE + execution.id, // we keep this prepared for repeat use
         iterationData,
-        self;
+        self = this,
+        responseAssertion,
+        requestAssertion;
 
     // @todo - ensure runtime passes data in a scope format
     iterationData = new VariableScope();
@@ -106,35 +108,34 @@ Postman = function Postman (bridge, execution, onRequest) {
         cookies: execution.cookies
     });
 
-    // Making a copy of the current context.
-    self = this;
-
     // extend pm api with test runner abilities
-    setupTestRunner(this, function (assertion) {
+    setupTestRunner(self, function (assertion) {
         bridge.dispatch(assertionEventName, execution.cursor, [assertion]);
         bridge.dispatch(EXECUTION_ASSERTION_EVENT, execution.cursor, [assertion]);
     });
 
     // add response assertions
-    if (this.response) {
+    if (self.response) {
         // these are removed before serializing see `purse.js`
-        this.response.to = {not: {}};
+        self.response.to = {not: {}};
+        responseAssertion = chai.expect(self.response).to;
 
         // explicitly assigning chai methods to chai's 'to' and 'to.not'.
         chainingMethods.forEach(function eachMethod (value) {
-            self.response.to[value] = chai.expect(self.response).to[value];
-            self.response.to.not[value] = chai.expect(self.response).to.not[value];
+            self.response.to[value] = responseAssertion.to[value];
+            self.response.to.not[value] = responseAssertion.not[value];
         });
     }
     // add request assertions
-    if (this.request) {
+    if (self.request) {
         // these are removed before serializing see `purse.js`
-        this.request.to = {not: {}};
+        self.request.to = {not: {}};
+        requestAssertion = chai.expect(self.request).to;
 
         // explicitly assigning chai methods to chai's 'to' and 'to.not'.
         chainingMethods.forEach(function eachMethod (value) {
-            self.request.to[value] = chai.expect(self.request).to[value];
-            self.request.to.not[value] = chai.expect(self.request).to.not[value];
+            self.request.to[value] = requestAssertion[value];
+            self.request.to.not[value] = requestAssertion.not[value];
         });
     }
 
@@ -144,7 +145,7 @@ Postman = function Postman (bridge, execution, onRequest) {
      * @param {Request|String} req
      * @param {Function} callback
      */
-    this.sendRequest = function (req, callback) {
+    self.sendRequest = function (req, callback) {
         if (!req) {
             return _.isFunction(callback) && callback.call(self, new Error('sendrequest: nothing to request'));
         }

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -120,6 +120,7 @@ Postman = function Postman (bridge, execution, onRequest) {
         // these are removed before serializing see `purse.js`
         this.response.to = {not: {}};
 
+        // explicitly assigning chai methods to chai's 'to' and 'to.not'.
         chainingMethods.forEach(function eachMethod (value) {
             self.response.to[value] = chai.expect(self.response).to[value];
             self.response.to.not[value] = chai.expect(self.response).to.not[value];
@@ -130,6 +131,7 @@ Postman = function Postman (bridge, execution, onRequest) {
         // these are removed before serializing see `purse.js`
         this.request.to = {not: {}};
 
+        // explicitly assigning chai methods to chai's 'to' and 'to.not'.
         chainingMethods.forEach(function eachMethod (value) {
             self.request.to[value] = chai.expect(self.request).to[value];
             self.request.to.not[value] = chai.expect(self.request).to.not[value];

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -7,7 +7,6 @@ var EXECUTION_ASSERTION_EVENT = 'execution.assertion',
     PostmanRequest = sdk.Request,
     PostmanResponse = sdk.Response,
     chai = require('chai'),
-    chainingMethods = ['be', 'have', 'include'],
 
     /**
      * Use this function to assign readonly properties to an object
@@ -32,6 +31,7 @@ var EXECUTION_ASSERTION_EVENT = 'execution.assertion',
     },
 
     setupTestRunner = require('./pmapi-setup-runner'),
+    setupChai = require('./pmapi-setup-chai'),
     Postman;
 
 /**
@@ -43,9 +43,7 @@ var EXECUTION_ASSERTION_EVENT = 'execution.assertion',
 Postman = function Postman (bridge, execution, onRequest) {
     var assertionEventName = EXECUTION_ASSERTION_EVENT_BASE + execution.id, // we keep this prepared for repeat use
         iterationData,
-        self = this,
-        responseAssertion,
-        requestAssertion;
+        self = this;
 
     // @todo - ensure runtime passes data in a scope format
     iterationData = new VariableScope();
@@ -114,30 +112,7 @@ Postman = function Postman (bridge, execution, onRequest) {
         bridge.dispatch(EXECUTION_ASSERTION_EVENT, execution.cursor, [assertion]);
     });
 
-    // add response assertions
-    if (self.response) {
-        // these are removed before serializing see `purse.js`
-        self.response.to = {not: {}};
-        responseAssertion = chai.expect(self.response).to;
-
-        // explicitly assigning chai methods to chai's 'to' and 'to.not'.
-        chainingMethods.forEach(function eachMethod (value) {
-            self.response.to[value] = responseAssertion.to[value];
-            self.response.to.not[value] = responseAssertion.not[value];
-        });
-    }
-    // add request assertions
-    if (self.request) {
-        // these are removed before serializing see `purse.js`
-        self.request.to = {not: {}};
-        requestAssertion = chai.expect(self.request).to;
-
-        // explicitly assigning chai methods to chai's 'to' and 'to.not'.
-        chainingMethods.forEach(function eachMethod (value) {
-            self.request.to[value] = requestAssertion[value];
-            self.request.to.not[value] = requestAssertion.not[value];
-        });
-    }
+    self = setupChai(self, chai);
 
     /**
      * Allows one to send request from script.
@@ -163,9 +138,6 @@ Postman = function Postman (bridge, execution, onRequest) {
 
 // expose chai assertion library via prototype
 Postman.prototype.expect = chai.expect;
-
-// make chai use postman extension
-chai.use(require('chai-postman')(sdk, _));
 
 // export
 module.exports = Postman;

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -7,6 +7,7 @@ var EXECUTION_ASSERTION_EVENT = 'execution.assertion',
     PostmanRequest = sdk.Request,
     PostmanResponse = sdk.Response,
     chai = require('chai'),
+    chainingMethods = ['be', 'have', 'include'],
 
     /**
      * Use this function to assign readonly properties to an object
@@ -41,7 +42,8 @@ var EXECUTION_ASSERTION_EVENT = 'execution.assertion',
  */
 Postman = function Postman (bridge, execution, onRequest) {
     var assertionEventName = EXECUTION_ASSERTION_EVENT_BASE + execution.id, // we keep this prepared for repeat use
-        iterationData;
+        iterationData,
+        self;
 
     // @todo - ensure runtime passes data in a scope format
     iterationData = new VariableScope();
@@ -104,6 +106,9 @@ Postman = function Postman (bridge, execution, onRequest) {
         cookies: execution.cookies
     });
 
+    // Making a copy of the current context.
+    self = this;
+
     // extend pm api with test runner abilities
     setupTestRunner(this, function (assertion) {
         bridge.dispatch(assertionEventName, execution.cursor, [assertion]);
@@ -113,12 +118,22 @@ Postman = function Postman (bridge, execution, onRequest) {
     // add response assertions
     if (this.response) {
         // these are removed before serializing see `purse.js`
-        this.response.to = chai.expect(this.response).to;
+        this.response.to = {not: {}};
+
+        chainingMethods.forEach(function eachMethod (value) {
+            self.response.to[value] = chai.expect(self.response).to[value];
+            self.response.to.not[value] = chai.expect(self.response).to.not[value];
+        });
     }
     // add request assertions
     if (this.request) {
         // these are removed before serializing see `purse.js`
-        this.request.to = chai.expect(this.request).to;
+        this.request.to = {not: {}};
+
+        chainingMethods.forEach(function eachMethod (value) {
+            self.request.to[value] = chai.expect(self.request).to[value];
+            self.request.to.not[value] = chai.expect(self.request).to.not[value];
+        });
     }
 
     /**
@@ -128,7 +143,6 @@ Postman = function Postman (bridge, execution, onRequest) {
      * @param {Function} callback
      */
     this.sendRequest = function (req, callback) {
-        var self = this;
         if (!req) {
             return _.isFunction(callback) && callback.call(self, new Error('sendrequest: nothing to request'));
         }

--- a/test/unit/execution.test.js
+++ b/test/unit/execution.test.js
@@ -12,7 +12,15 @@ var _ = require('lodash'),
 describe('execution', function () {
     before(function () {
         execution = new Execution('id', {listen: 'test'}, {}, {});
-        pm = new pmAPI({}, execution, _.noop);
+        pm = new pmAPI({
+            request: 'https://postman-echo.com/',
+            response: {
+                body: {
+
+                }
+            },
+            dispatch: _.noop
+        }, execution, _.noop);
     });
 
     it('can be serialized', function () {
@@ -38,5 +46,21 @@ describe('execution', function () {
         expect(json).to.have.property('response');
         expect(json.response).to.not.have.property('to');
         expect(execution.response).to.have.property('to');
+    });
+
+    it('Negating a single assertion on pm.request should not negate the assertions following it.', function () {
+        pm.request.to.not.be.null;
+        pm.request.to.be.an('object');
+        pm.request.to.not.be.undefined;
+        pm.request.to.not.be.a('string');
+        pm.request.to.be.an('object').to.have.property('url');
+    });
+
+    it('Negating a single assertion on pm.response should not negate the assertions following it.', function () {
+        pm.response.to.not.be.null;
+        pm.response.to.be.an('object');
+        pm.response.to.not.be.undefined;
+        pm.response.to.not.be.a('string');
+        pm.response.to.be.an('object').to.have.property('headers');
     });
 });

--- a/test/unit/execution.test.js
+++ b/test/unit/execution.test.js
@@ -51,7 +51,7 @@ describe('execution', function () {
         pm.request.to.be.an('object');
         pm.request.to.not.be.undefined;
         pm.request.to.not.be.a('string');
-        pm.request.to.be.an('object').to.have.property('url');
+        pm.request.to.be.an('object').that.has.property('url');
     });
 
     it('Negating a single assertion on pm.response should not negate the assertions following it.', function () {
@@ -59,6 +59,6 @@ describe('execution', function () {
         pm.response.to.be.an('object');
         pm.response.to.not.be.undefined;
         pm.response.to.not.be.a('string');
-        pm.response.to.be.an('object').to.have.property('headers');
+        pm.response.to.be.an('object').that.has.property('headers');
     });
 });

--- a/test/unit/execution.test.js
+++ b/test/unit/execution.test.js
@@ -15,9 +15,7 @@ describe('execution', function () {
         pm = new pmAPI({
             request: 'https://postman-echo.com/',
             response: {
-                body: {
-
-                }
+                body: {}
             },
             dispatch: _.noop
         }, execution, _.noop);


### PR DESCRIPTION
This ensures that the chai's assertion methods are correctly assigned to pm.request.to and pm.response.to, hence helping us to overcome a bug where once a test assertion was negated, caused the subsequent following assertions to get negated as well. 

https://github.com/postmanlabs/postman-app-support/issues/3690

To counter this we explicitly assign the top level chai's chain-able methods to the pm.request to and pm.request.to.not, same for pm.response.

Added chai assignment for pm.request.
Added test case for negation on pm.request.

Added chai assignment for pm.response.
Added test case for negation on pm.response.