### PR TITLE
Revert "Added node 10 to CI matrix and dropped node 4"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,9 +9,9 @@ init:
 # environment variables
 environment:
   matrix:
+    - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
-    - nodejs_version: "10"
 
 # scripts that run after cloning repository
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 dist: trusty
 language: node_js
 node_js:
+- '4'
 - '6'
 - '8'
-- '10'
 addons:
   apt:
     packages:

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "crypto-js": "3.1.9-1",
     "csv-parse": "1.2.4",
     "editorconfig": "0.15.0",
-    "eslint": "5.0.1",
+    "eslint": "4.19.1",
     "eslint-plugin-jsdoc": "3.7.1",
     "eslint-plugin-lodash": "2.7.0",
     "eslint-plugin-mocha": "4.11.0",

--- a/test/system/travis-yml.test.js
+++ b/test/system/travis-yml.test.js
@@ -29,7 +29,7 @@ describe('travis.yml', function () {
 
         it('should have the language set to node', function () {
             expect(travisYAML.language).to.be('node_js');
-            expect(travisYAML.node_js).to.eql(['6', '8', '10']);
+            expect(travisYAML.node_js).to.eql(['4', '6', '8']);
         });
 
         it('should use the stable google chrome package', function () {


### PR DESCRIPTION
Reverts postmanlabs/postman-sandbox#316

Added support for node v4. Waiting until we drop support for node v4 in `postman-runtime` in the next major release.