### PR TITLE
Use getter for pm.request.to and pm.response.to assertions

### DIFF
--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -113,12 +113,20 @@ Postman = function Postman (bridge, execution, onRequest) {
     // add response assertions
     if (this.response) {
         // these are removed before serializing see `purse.js`
-        this.response.to = chai.expect(this.response).to;
+        Object.defineProperty(this.response, 'to', {
+            get: function () {
+                return chai.expect(this).to;
+            }
+        });
     }
     // add request assertions
     if (this.request) {
         // these are removed before serializing see `purse.js`
-        this.request.to = chai.expect(this.request).to;
+        Object.defineProperty(this.request, 'to', {
+            get: function () {
+                return chai.expect(this).to;
+            }
+        });
     }
 
     /**

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -425,6 +425,13 @@ describe('sandbox library - pm api', function () {
 
                 // run a test as well ;-)
                 pm.response.to.be.ok;
+                pm.response.to.not.be.a.postmanRequest;
+
+                pm.response.to.not.be.serverError;
+                pm.response.to.not.have.statusCode(400);
+
+                pm.response.to.have.statusCode(200);
+                pm.response.to.have.statusReason('OK');
             `, {
                 context: {
                     response: {code: 200}
@@ -436,9 +443,24 @@ describe('sandbox library - pm api', function () {
             context.execute(`
                 pm.expect(pm.request).to.have.property('to');
                 pm.expect(pm.request.to).to.be.an('object');
+
+                pm.request.to.be.ok;
+
+                pm.request.to.not.be.a.postmanResponse;
+                pm.request.to.not.have.header('Foo-Bar');
+
+                pm.request.to.have.header('Content-Type');
+                pm.request.to.be.a.postmanRequestOrResponse;
+
             `, {
                 context: {
-                    request: 'https://postman-echo.com/'
+                    request: {
+                        url: 'https://postman-echo.com/',
+                        header: [{
+                            key: 'Content-Type',
+                            value: 'application/json; charset=utf-8'
+                        }]
+                    }
                 }
             }, done);
         });


### PR DESCRIPTION
**Issue:**
Direct `chai.expect(..).to`  assignment to `pm.request.to` and `pm. response.to` holds the same state for all the assertion.
When `.not` is added to the assertion chain, `negated` flag turns to true in the state which will be persisted for all the assertions done after it.

**Solution:**
Using getter every time the `.to` property is accessed, it will return a new instance of `chai.expect(..).to`.

Reference: https://github.com/postmanlabs/postman-app-support/issues/3592

**Memory Benchmarks:**
- AJV Library
- Current Change

![output](https://user-images.githubusercontent.com/4865836/50387306-ce1e0d00-071e-11e9-9a94-5a252c8f72eb.png)
