### PR TITLE
Add option `serialiseConsole` to enable sending `teleport-javascript` serialised console logs

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+master:
+  new features:
+    - GH-502 Added support for non-JSON compatible data types in console logs
+
 3.4.0:
   date: 2019-10-01
   new features:

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,9 @@
 master:
   new features:
     - GH-502 Added support for non-JSON compatible data types in console logs
+    - |
+      GH-502 Added option `serializeLogs` to allow sending `teleport-javascript`
+      serialized logs
 
 3.4.0:
   date: 2019-10-01

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,6 +51,7 @@ _.assign(PostmanSandbox.prototype, {
      * @param {Number} options.timeout
      * @param {Object} options.cursor
      * @param {Object} options.context
+     * @param {Boolean} options.serializeLogs
      * @param {Function} callback
      */
     execute: function (target, options, callback) {
@@ -105,6 +106,10 @@ _.assign(PostmanSandbox.prototype, {
         });
 
         this.on(consoleEventName, function (cursor, level, args) {
+            if (_.get(options, 'serializeLogs')) {
+                return this.emit('console', cursor, level, args);
+            }
+
             args = teleportJS.parse(args);
             args.unshift('console', cursor, level);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ var _ = require('lodash'),
     uuid = require('uuid'),
     UniversalVM = require('uvm'),
     PostmanEvent = require('postman-collection').Event,
+    teleportJS = require('teleport-javascript'),
     bootcode = require('./bootcode'),
 
     TO_WAITBUFFER = 500, // time to wait for sandbox to delcare timeout
@@ -73,6 +74,7 @@ _.assign(PostmanSandbox.prototype, {
 
         var id = _.isString(options.id) ? options.id : uuid(),
             executionEventName = 'execution.result.' + id,
+            consoleEventName = 'execution.console.' + id,
             executionTimeout = _.get(options, 'timeout', this.executionTimeout),
             cursor = _.clone(_.get(options, 'cursor', {})), // clone the cursor as it travels through IPC for mutation
             debugMode = _.has(options, 'debug') ? options.debug : this.debug,
@@ -100,6 +102,13 @@ _.assign(PostmanSandbox.prototype, {
 
             this.emit('execution', err, id, result);
             callback(err, result);
+        });
+
+        this.on(consoleEventName, function (cursor, level, args) {
+            args = teleportJS.parse(args);
+            args.unshift('console', cursor, level);
+
+            this.emit.apply(this, args);
         });
 
         // send the code to the sandbox to be intercepted and executed

--- a/lib/sandbox/console.js
+++ b/lib/sandbox/console.js
@@ -1,10 +1,12 @@
-var arrayProtoSlice = Array.prototype.slice,
+var teleportJS = require('teleport-javascript'),
+
+    arrayProtoSlice = Array.prototype.slice,
 
     /**
      * @constant
      * @type {String}
      */
-    CONSOLE = 'console',
+    CONSOLE_EVENT_BASE = 'execution.console.',
 
     /**
      * List of functions that we expect and create for console
@@ -15,14 +17,16 @@ var arrayProtoSlice = Array.prototype.slice,
 
     PostmanConsole;
 
-PostmanConsole = function PostmanConsole (emitter, cursor, originalConsole) {
-    var dispatch = (originalConsole ? function (level) { // create a dispatch function that emits events
+PostmanConsole = function PostmanConsole (emitter, id, cursor, originalConsole) {
+    var dispatch = function (level) { // create a dispatch function that emits events
         var args = arrayProtoSlice.call(arguments, 1);
-        originalConsole[level].apply(originalConsole, args);
 
-        args.unshift(CONSOLE, cursor, level);
-        emitter.dispatch.apply(emitter, args);
-    } : emitter.dispatch.bind(emitter, CONSOLE, cursor)); // bind only to emitter if no original console is sent
+        if (originalConsole) {
+            originalConsole[level].apply(originalConsole, args);
+        }
+
+        emitter.dispatch(CONSOLE_EVENT_BASE + id, cursor, level, teleportJS.stringify(args));
+    };
 
     // setup variants of the logger based on log levels
     logLevels.forEach(function (name) {

--- a/lib/sandbox/execute.js
+++ b/lib/sandbox/execute.js
@@ -119,7 +119,7 @@ module.exports = function (bridge, glob) {
         executeContext(scope, code, execution,
             // if a console is sent, we use it. otherwise this also prevents erroneous referencing to any console
             // inside this closure.
-            (new PostmanConsole(bridge, options.cursor, options.debug && glob.console)),
+            (new PostmanConsole(bridge, id, options.cursor, options.debug && glob.console)),
             timers,
             (new PostmanAPI(bridge, execution, function (request, callback) {
                 var eventId = timers.setEvent(callback);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6560,6 +6560,11 @@
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
     },
+    "teleport-javascript": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/teleport-javascript/-/teleport-javascript-0.1.0.tgz",
+      "integrity": "sha512-ovZglnoWIaH0Zqz1qiYwbWrlYhwfYQt3MDjTMB4SGpttsD9maWuV3aW0RvMLohUNj7zdJ4jICOyXkRDD4UCtAQ=="
+    },
     "temp-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "inherits": "2.0.4",
     "lodash": "4.17.15",
+    "teleport-javascript": "0.1.0",
     "tough-cookie": "3.0.1",
     "uuid": "3.3.3",
     "uvm": "1.7.8"

--- a/test/system/bootcode-dependencies.test.js
+++ b/test/system/bootcode-dependencies.test.js
@@ -114,6 +114,7 @@ describe('bootcode dependencies', function () {
             'stream-browserify',
             'string_decoder',
             'supports-color',
+            'teleport-javascript',
             'timers-browserify',
             'tough-cookie',
             'tv4',

--- a/test/unit/sandbox-console.test.js
+++ b/test/unit/sandbox-console.test.js
@@ -18,7 +18,9 @@ describe('console inside sandbox', function () {
                     consoleEventArgs = arguments;
                 });
 
-                ctx.execute(`console.${level}('hello console');`, {cursor: {ref: 'cursor-identifier'}}, function (err) {
+                ctx.execute(`console.${level}('hello console');`, {
+                    cursor: {ref: 'cursor-identifier'}
+                }, function (err) {
                     if (err) { return done(err); }
                     expect(consoleEventArgs).to.be.ok;
                     expect(consoleEventArgs[0]).be.an('object').that.has.property('ref', 'cursor-identifier');
@@ -27,6 +29,64 @@ describe('console inside sandbox', function () {
                     expect(consoleEventArgs[2]).to.equal('hello console');
                     done();
                 });
+            });
+        });
+    });
+
+    it('should be able to display all datatypes in console logs', function (done) {
+        Sandbox.createContext({}, function (err, ctx) {
+            var logsData = {
+                    regex: /a-z/g,
+                    nil: null,
+                    undef: undefined,
+                    string: 'some str',
+                    number: 1234,
+                    boolean: true,
+                    arr: [1, 2, 3],
+                    obj: {
+                        a: 1,
+                        b: 2
+                    },
+                    map: new Map([[1, 'one'], [2, 'two']]),
+                    set: new Set([1, 2, 3])
+                },
+                consoleEventArgs;
+
+            if (err) {
+                return done(err);
+            }
+
+            ctx.on('error', done);
+            ctx.on('console', function () {
+                consoleEventArgs = arguments;
+            });
+
+            ctx.execute(`console.log({
+                    regex: /a-z/g,
+                    nil: null,
+                    undef: undefined,
+                    string: 'some str',
+                    number: 1234,
+                    boolean: true,
+                    arr: [1, 2, 3],
+                    obj: {
+                        a: 1,
+                        b: 2
+                    },
+                    map: new Map([[1, 'one'], [2, 'two']]),
+                    set: new Set([1, 2, 3])
+                }, /a-z/g);`, {}, function (err) {
+
+                if (err) {
+                    return done(err);
+                }
+
+                expect(consoleEventArgs).to.exist;
+                expect(consoleEventArgs[0]).to.be.an('object');
+                expect(consoleEventArgs[1]).to.be.a('string').and.equal('log');
+                expect(consoleEventArgs[2]).to.be.an('object').and.eql(logsData);
+                expect(consoleEventArgs[3]).to.be.a('regexp').and.eql(/a-z/g);
+                done();
             });
         });
     });

--- a/test/unit/sandbox-console.test.js
+++ b/test/unit/sandbox-console.test.js
@@ -1,3 +1,5 @@
+var teleportJS = require('teleport-javascript');
+
 // @todo use sinopia
 describe('console inside sandbox', function () {
     this.timeout(1000 * 60);
@@ -86,6 +88,102 @@ describe('console inside sandbox', function () {
                 expect(consoleEventArgs[1]).to.be.a('string').and.equal('log');
                 expect(consoleEventArgs[2]).to.be.an('object').and.eql(logsData);
                 expect(consoleEventArgs[3]).to.be.a('regexp').and.eql(/a-z/g);
+                done();
+            });
+        });
+    });
+
+    it('should allow sending serialized logs', function (done) {
+        Sandbox.createContext({}, function (err, ctx) {
+            var logsData = {
+                    undef: undefined,
+                    str: 'string'
+                },
+                expectedLogs = teleportJS.stringify([logsData]),
+                consoleEventArgs;
+
+            if (err) {
+                return done(err);
+            }
+
+            ctx.on('error', done);
+            ctx.on('console', function () {
+                consoleEventArgs = arguments;
+            });
+
+            ctx.execute('console.log({ undef: undefined, str: "string" });', {
+                serializeLogs: true
+            }, function (err) {
+
+                if (err) {
+                    return done(err);
+                }
+
+                expect(consoleEventArgs).to.exist;
+                expect(consoleEventArgs[0]).to.be.an('object');
+                expect(consoleEventArgs[1]).to.be.a('string').and.equal('log');
+                expect(consoleEventArgs[2]).to.be.a('string').and.equal(expectedLogs);
+                expect(teleportJS.parse(consoleEventArgs[2])).to.eql([logsData]);
+                done();
+            });
+        });
+    });
+
+    it('should allow calling console.log without arguments', function (done) {
+        Sandbox.createContext({}, function (err, ctx) {
+            var consoleEventArgs;
+
+            if (err) {
+                return done(err);
+            }
+
+            ctx.on('error', done);
+            ctx.on('console', function () {
+                consoleEventArgs = arguments;
+            });
+
+            ctx.execute('console.log();', {
+                serializeLogs: false
+            }, function (err) {
+
+                if (err) {
+                    return done(err);
+                }
+
+                expect(consoleEventArgs).to.exist;
+                expect(consoleEventArgs[0]).to.be.an('object');
+                expect(consoleEventArgs[1]).to.be.a('string').and.equal('log');
+                expect(consoleEventArgs[2]).to.be.undefined;
+                done();
+            });
+        });
+    });
+
+    it('should allow calling console.log without arguments with serializeLogs options set', function (done) {
+        Sandbox.createContext({}, function (err, ctx) {
+            var consoleEventArgs;
+
+            if (err) {
+                return done(err);
+            }
+
+            ctx.on('error', done);
+            ctx.on('console', function () {
+                consoleEventArgs = arguments;
+            });
+
+            ctx.execute('console.log();', {
+                serializeLogs: true
+            }, function (err) {
+
+                if (err) {
+                    return done(err);
+                }
+
+                expect(consoleEventArgs).to.exist;
+                expect(consoleEventArgs[0]).to.be.an('object');
+                expect(consoleEventArgs[1]).to.be.a('string').and.equal('log');
+                expect(consoleEventArgs[2]).to.be.a('string').and.equal('[[]]');
                 done();
             });
         });


### PR DESCRIPTION
Adds `teleport-javascript` for serialising console logs.

PS: Added option for enabling this feature as well. (Can be deleted if we want this behaviour always).