### PR TITLE
Fix asynchronous scripts execution in browser

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+master:
+  fixed bugs:
+    - GH-589 Fixed a bug where asynchronous scripts are not executed in the browser
+
 3.5.5:
   date: 2020-06-14
   chores:

--- a/README.md
+++ b/README.md
@@ -63,3 +63,9 @@ The following section outlines the API available inside sandbox scripts
 - execution.response.*
 - execution.cookies.*
 - execution.console.*
+
+## Contributing
+
+### Debug in browser
+
+To debug tests in Chrome's DevTools, start tests using `npm run test-browser -- --debug` and click `DEBUG`.

--- a/lib/sandbox/timers.js
+++ b/lib/sandbox/timers.js
@@ -46,20 +46,42 @@ var /**
     /**
      * This object holds the current global timers
      * @extends Timers
+     *
+     * @note This is a very important piece of code from compatibility standpoint.
+     * The global timers need to be returned as a function that does not hold reference to the scope
+     * and does not retain references to scope. Aditionally, the invocation of the timer function is
+     * done without changing the scope to avoid Illegal Invocation errors.
+     *
+     * `timerFunctionNames` returns the suffixes of all timer operations that needs a
+     * a setter and clear method.
      */
     defaultTimers = timerFunctionNames.reduce(function (timers, name) {
-        // get hold of default timer functions as available in global scope
-        var fnset = (new Function(`return typeof set${name} === 'function' ?` + // eslint-disable-line no-new-func
-                `function (fn, ms) { return set${name}(fn, ms); } : undefined;`))(),
-            fnclr = (new Function(`return typeof clear${name} === 'function' ?` + // eslint-disable-line no-new-func
-                `function (id) { return clear${name}(id); } : undefined;`))();
+        var
 
-        if (typeof fnset === FUNCTION) {
-            timers[('set' + name)] = fnset;
+            /**
+             * Check if global setter function is available
+             * @private
+             * @type {Boolean}
+             */
+            // eslint-disable-next-line no-new-func
+            isGlobalSetterAvailable = (new Function(`return typeof set${name} === 'function'`))(),
+
+            /**
+             * Check if global clear function is available
+             * @private
+             * @type {Boolean}
+             */
+            // eslint-disable-next-line no-new-func
+            isGlobalClearAvailable = (new Function(`return typeof clear${name} === 'function'`))();
+
+        if (isGlobalSetterAvailable) {
+            // eslint-disable-next-line no-new-func
+            timers[('set' + name)] = (new Function(`return function (fn, ms) { return set${name}(fn, ms); }`))();
         }
 
-        if (typeof fnclr === FUNCTION) {
-            timers[('clear' + name)] = fnclr;
+        if (isGlobalClearAvailable) {
+            // eslint-disable-next-line no-new-func
+            timers[('clear' + name)] = (new Function(`return function (id) { return clear${name}(id); }`))();
         }
 
         return timers;

--- a/lib/sandbox/timers.js
+++ b/lib/sandbox/timers.js
@@ -49,10 +49,10 @@ var /**
      */
     defaultTimers = timerFunctionNames.reduce(function (timers, name) {
         // get hold of default timer functions as available in global scope
-        var fnset = (new Function('return (typeof set' + name + // eslint-disable-line no-new-func
-                ' === "function" ? set' + name + ' : undefined);'))(),
-            fnclr = (new Function('return (typeof clear' + name + // eslint-disable-line no-new-func
-                ' === "function" ? clear' + name + ' : undefined);'))();
+        var fnset = (new Function(`return typeof set${name} === 'function' ?` + // eslint-disable-line no-new-func
+                `function (fn, ms) { return set${name}(fn, ms); } : undefined;`))(),
+            fnclr = (new Function(`return typeof clear${name} === 'function' ?` + // eslint-disable-line no-new-func
+                `function (id) { return clear${name}(id); } : undefined;`))();
 
         if (typeof fnset === FUNCTION) {
             timers[('set' + name)] = fnset;

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -84,5 +84,11 @@ module.exports = function (config) {
         configuration.browsers = ['chromeTravis'];
     }
 
+    // Use `npm run test-browser -- --debug` to debug tests in Chrome console
+    if (process.argv[2] === '--debug') {
+        configuration.browsers = ['Chrome'];
+        configuration.singleRun = false;
+    }
+
     config.set(configuration);
 };

--- a/test/unit/sandbox-assertions.test.js
+++ b/test/unit/sandbox-assertions.test.js
@@ -96,7 +96,7 @@ describe('sandbox test assertion', function () {
         });
     });
 
-    (typeof window === 'undefined' ? it : it.skip)('should call the assertion event on async test', function (done) {
+    it('should call the assertion event on async test', function (done) {
         Sandbox.createContext({debug: true}, function (err, ctx) {
             if (err) { return done(err); }
 
@@ -131,7 +131,7 @@ describe('sandbox test assertion', function () {
         });
     });
 
-    (typeof window === 'undefined' ? it : it.skip)('should not wait if async done is not called', function (done) {
+    it('should not wait if async done is not called', function (done) {
         Sandbox.createContext({debug: true}, function (err, ctx) {
             if (err) { return done(err); }
 
@@ -157,7 +157,7 @@ describe('sandbox test assertion', function () {
         });
     });
 
-    (typeof window === 'undefined' ? it : it.skip)('should terminate script ' +
+    it('should terminate script ' +
         'if async done is not called in an async script', function (done) {
         Sandbox.createContext({debug: true}, function (err, ctx) {
             if (err) { return done(err); }
@@ -186,7 +186,7 @@ describe('sandbox test assertion', function () {
         });
     });
 
-    (typeof window === 'undefined' ? it : it.skip)('should forward errors from asynchronous callback', function (done) {
+    it('should forward errors from asynchronous callback', function (done) {
         Sandbox.createContext({debug: true}, function (err, ctx) {
             if (err) { return done(err); }
 
@@ -225,7 +225,7 @@ describe('sandbox test assertion', function () {
         });
     });
 
-    (typeof window === 'undefined' ? it : it.skip)('should forward synchronous' +
+    it('should forward synchronous' +
         'errors from asynchronous tests', function (done) {
         Sandbox.createContext({debug: true}, function (err, ctx) {
             if (err) { return done(err); }

--- a/test/unit/sandbox-libraries/ajv.test.js
+++ b/test/unit/sandbox-libraries/ajv.test.js
@@ -70,7 +70,7 @@ describe('sandbox library - AJV', function () {
             `, done);
         });
 
-        (typeof window === 'undefined' ? it : it.skip)('compileAsync', function (done) {
+        it('compileAsync', function (done) {
             context.execute(`
                 var Ajv = require('ajv'),
 

--- a/test/unit/sandbox-timeout.test.js
+++ b/test/unit/sandbox-timeout.test.js
@@ -1,3 +1,5 @@
+// @todo find ways to support basic timeout, if not the real ones that protect
+// against infinite loops, but at least ones that can emulate the timeout APIs
 (typeof window === 'undefined' ? describe : describe.skip)('sandbox timeout', function () {
     this.timeout(1000 * 60);
     var Sandbox = require('../../lib');

--- a/test/unit/sandbox-timers.test.js
+++ b/test/unit/sandbox-timers.test.js
@@ -1,4 +1,4 @@
-(typeof window === 'undefined' ? describe : describe.skip)('timers inside sandbox', function () {
+describe('timers inside sandbox', function () {
     this.timeout(1000 * 60);
     var Sandbox = require('../../lib'),
         ctx;


### PR DESCRIPTION
Fixed a bug where asynchronous scripts using timers are not executed in the browser sandbox.

* Wrap `timers` method in an anonymous function to avoid timer functions (`set*` and `clear*`) to use the `timers` scope.
* Add `--debug` flag to help debug browser tests. `npm run test-browser -- --debug`