### PR TITLE
Changes to generate type-definitions from jsdoc comments for postman-sandbox

### DIFF
--- a/.jsdoc-config-type-def-sandbox.json
+++ b/.jsdoc-config-type-def-sandbox.json
@@ -1,0 +1,33 @@
+{
+  "tags": {
+    "allowUnknownTags": true,
+    "dictionaries": [
+      "jsdoc",
+      "closure"
+    ]
+  },
+  "source": {
+    "include": [
+      "lib/sandbox/pmapi.js",
+      "lib/sandbox/execute-context.js",
+      "lib/sandbox/cookie-jar.js"
+    ],
+    "includePattern": ".+\\.js(doc)?$",
+    "excludePattern": "(^|\\/|\\\\)_"
+  },
+  "plugins": [
+    "tsd-jsdoc/dist/plugin"
+  ],
+  "templates": {
+    "cleverLinks": true,
+    "default": {
+      "outputSourceFiles": false
+    }
+  },
+  "opts": {
+    "destination": "./types/sandbox/",
+    "template": "tsd-jsdoc/dist",
+    "outFile": "index.d.ts",
+    "recurse": true
+  }
+}

--- a/.jsdoc-config-type-def.json
+++ b/.jsdoc-config-type-def.json
@@ -1,0 +1,31 @@
+{
+  "tags": {
+    "allowUnknownTags": true,
+    "dictionaries": [
+      "jsdoc",
+      "closure"
+    ]
+  },
+  "source": {
+    "include": [
+      "lib/sandbox"
+    ],
+    "includePattern": ".+\\.js(doc)?$",
+    "excludePattern": "(^|\\/|\\\\)_"
+  },
+  "plugins": [
+    "tsd-jsdoc/dist/plugin"
+  ],
+  "templates": {
+    "cleverLinks": true,
+    "default": {
+      "outputSourceFiles": false
+    }
+  },
+  "opts": {
+    "destination": "./types",
+    "template": "tsd-jsdoc/dist",
+    "outFile": "index.d.ts",
+    "recurse": true
+  }
+}

--- a/lib/sandbox/cookie-jar.js
+++ b/lib/sandbox/cookie-jar.js
@@ -168,6 +168,10 @@ var CookieJar = require('tough-cookie').CookieJar,
 
     PostmanCookieJar;
 
+/**
+ * @typeof PostmanCookieJar
+ * @interface
+ */
 PostmanCookieJar = function PostmanCookieJar (cookieStore) {
     this.store = cookieStore;
     this.jar = new CookieJar(cookieStore, {

--- a/lib/sandbox/execute-context.js
+++ b/lib/sandbox/execute-context.js
@@ -32,6 +32,12 @@ module.exports = function (scope, code, execution, console, timers, pmapi) {
         // forward console
         console: console,
         // forward pm-api instance
+        /**
+         * The pm object encloses all information pertaining to the script being executed and
+         * allows one to access a copy of the request being sent or the response received.
+         * It also allows one to get and set environment and global variables.
+         * @type {Postman}
+         */
         pm: pmapi,
         // import the timers
         setTimeout: timers.setTimeout,

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -65,15 +65,51 @@ Postman = function Postman (bridge, execution, onRequest, cookieStore) {
 
     _assignDefinedReadonly(this, /** @lends Postman.prototype */ {
         /**
-         * Contains information pertaining to the script execution
+        * Contains information pertaining to the script execution
          *
-         * @type {Object}
+         * @interface Info
          */
-        info: _assignDefinedReadonly({}, {
+
+        /**
+         * The pm.info object contains information pertaining to the script being executed.
+         * Useful information such as the request name, request Id, and iteration count are
+         * stored inside of this object.
+         * @type {Info}
+         */
+        info: _assignDefinedReadonly({}, /** @lends Info */ {
+            /**
+             * Contains information whether the script being executed is a "prerequest" or a "test" script.
+             * @type {string}
+             * @instance
+             */
             eventName: execution.target,
+
+            /**
+             * Is the value of the current iteration being run.
+             * @type {number}
+             * @instance
+             */
             iteration: execution.cursor.iteration,
+
+            /**
+             * Is the total number of iterations that are scheduled to run.
+             * @type {number}
+             * @instance
+             */
             iterationCount: execution.cursor.cycles,
+
+            /**
+             * The saved name of the individual request being run.
+             * @type {string}
+             * @instance
+             */
             requestName: execution.legacy._itemName,
+
+            /**
+             * The unique guid that identifies the request being run.
+             * @type {string}
+             * @instance
+             */
             requestId: execution.legacy._itemId
         }),
 
@@ -98,32 +134,44 @@ Postman = function Postman (bridge, execution, onRequest, cookieStore) {
         variables: execution._variables,
 
         /**
+         * The iterationData object contains data from the data file provided during a collection run.
          * @type {VariableScope}
          */
         iterationData: iterationData,
 
         /**
+         * The request object inside pm is a representation of the request for which this script is being run.
+         * For a pre-request script, this is the request that is about to be sent and when in a test script,
+         * this is the representation of the request that was sent.
          * @type {Request}
          */
         request: execution.request,
 
         /**
+         * Inside the test scripts, the pm.response object contains all information pertaining
+         * to the response that was received.
          * @type {Response}
+         * @customexclude true
          */
         response: execution.response,
 
         /**
+         * The cookies object contains a list of cookies that are associated with the domain
+         * to which the request was made.
          * @type {CookieList}
          */
         cookies: execution.cookies,
 
         /**
-         * @type {Object}
+         * @interface Visualizer
          */
-        visualizer: {
+        /**
+         * @type {Visualizer}
+         */
+        visualizer: /** @lends Visualizer */ {
             /**
              * Set visualizer template and its options
-             *
+             * @instance
              * @param {String} template - visualisation layout in form of template
              * @param {Object} [data] - data object to be used in template
              * @param {Object} [options] - options to use while processing the template
@@ -142,7 +190,6 @@ Postman = function Postman (bridge, execution, onRequest, cookieStore) {
                 }
 
                 /**
-                 * @typedef {Object} Visualizer
                  *
                  * @property {String} template - template string
                  * @property {Object} data - data to use while processing template
@@ -157,6 +204,7 @@ Postman = function Postman (bridge, execution, onRequest, cookieStore) {
 
             /**
              * Clear all visualizer data
+             * @instance
              */
             clear: function () {
                 execution.return.visualizer = undefined;
@@ -190,7 +238,7 @@ Postman = function Postman (bridge, execution, onRequest, cookieStore) {
     }
 
     /**
-     * Allows one to send request from script.
+     * Allows one to send request from script asynchronously.
      *
      * @param {Request|String} req
      * @param {Function} callback
@@ -218,6 +266,9 @@ Postman = function Postman (bridge, execution, onRequest, cookieStore) {
 };
 
 // expose chai assertion library via prototype
+/**
+ * @type {Chai.ExpectStatic}
+ */
 Postman.prototype.expect = chai.expect;
 
 // make chai use postman extension

--- a/npm/build-sandbox-types.js
+++ b/npm/build-sandbox-types.js
@@ -13,7 +13,6 @@ var path = require('path'),
     shell = require('shelljs'),
     typescript = require('typescript'),
     templates = require('./utils/templates'),
-    _ = require('lodash'),
 
     IS_WINDOWS = (/^win/).test(process.platform),
     TARGET_DIR = path.join('types', 'sandbox');

--- a/npm/build-sandbox-types.js
+++ b/npm/build-sandbox-types.js
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// ---------------------------------------------------------------------------------------------------------------------
+// This script is intended to generate type-definition for this module
+// ---------------------------------------------------------------------------------------------------------------------
+
+/* eslint-env node, es6 */
+require('shelljs/global');
+
+var path = require('path'),
+    fs = require('fs'),
+    chalk = require('chalk'),
+    async = require('async'),
+    shell = require('shelljs'),
+    typescript = require('typescript'),
+    templates = require('./utils/templates'),
+    _ = require('lodash'),
+
+    IS_WINDOWS = (/^win/).test(process.platform),
+    TARGET_DIR = path.join('types', 'sandbox');
+
+/**
+ * Generate pre-test script type-def
+ * @param {*} node
+ * @param {*} printer
+ */
+function generatePreScriptSource (node, printer) {
+    var source = '';
+    node.forEachChild((child) => {
+        var print = true,
+            excludedChildren = ['_assignDefinedReadonly', 'Visualizer', 'serialize', 'deserialize', 'sanitizeURL',
+                'forEachWithCallback', 'callbackHandler', 'PostmanCookieJar'],
+            excludedMembers = ['iterationData', 'response', 'cookies', 'visualizer', 'expect'];
+        if (child && child.name && child.name.escapedText) {
+            if (child.name.escapedText === 'Postman') {
+                child.members = child.members.filter((m) => {
+                    if (m.name && excludedMembers.includes(m.name.escapedText)) {
+                        return false;
+                    }
+                    return true;
+                });
+            }
+            if (excludedChildren.includes(child.name.escapedText)) {
+                print = false;
+            }
+        }
+        if (print) {
+            source += printer.printNode(
+                typescript.EmitHint.Unspecified,
+                child,
+                node
+            );
+            source += '\n\n';
+        }
+    });
+    source = source.slice(0, -2);
+    source += `${templates.postmanExtensionString}\n\n`;
+    return source;
+}
+
+/**
+ * Generate tests script type-def
+ * @param {*} node
+ * @param {*} printer
+ */
+function generateTestScriptSource (node, printer) {
+    var source = '';
+    node.forEachChild((child) => {
+        var print = true,
+            excludedChildren = ['_assignDefinedReadonly', 'serialize', 'deserialize', 'sanitizeURL',
+                'forEachWithCallback', 'callbackHandler'];
+        if (child && child.name && child.name.escapedText) {
+            if (excludedChildren.includes(child.name.escapedText)) {
+                print = false;
+            }
+        }
+        if (print) {
+            source += printer.printNode(
+                typescript.EmitHint.Unspecified,
+                child,
+                node
+            );
+            source += '\n\n';
+        }
+    });
+
+    source += `${templates.postmanExtensionString}\n\n`;
+    source += `${templates.cookieListExtensionString}\n\n`;
+    source += `${templates.responseExtensionString}`;
+    return source;
+}
+
+module.exports = function (exit) {
+    console.log(chalk.yellow.bold('Generating type-definitions...'));
+
+    try {
+        // clean directory
+        test('-d', TARGET_DIR) && rm('-rf', TARGET_DIR);
+        shell.mkdir('-p', TARGET_DIR);
+    }
+    catch (e) {
+        console.error(e.stack || e);
+        return exit(e ? 1 : 0);
+    }
+
+    exec(`${IS_WINDOWS ? '' : 'node'} ${path.join('node_modules', '.bin', 'jsdoc')}${IS_WINDOWS ? '.cmd' : ''}` +
+        ' -c .jsdoc-config-type-def-sandbox.json -p', function (code) {
+
+        if (!code) {
+            fs.readFile(`${TARGET_DIR}/index.d.ts`, function (err, contents) {
+                if (err) {
+                    console.log(chalk.red.bold('unable to read the type-definition file'));
+                    exit(1);
+                }
+                var preScriptSource = '',
+                    testScriptSource = '',
+                    files,
+                    source = contents.toString();
+                source = source
+                // replacing Integer with number as 'Integer' is not a valid data-type in Typescript
+                    .replace(/Integer/gm, 'number')
+                // replacing String[] with string[] as 'String' is not a valid data-type in Typescript
+                    .replace(/String\[]/gm, 'string[]')
+                // replacing Boolean[] with boolean[] as 'Boolean' is not a valid data-type in Typescript
+                    .replace(/Boolean\[]/gm, 'boolean[]')
+                // removing all occurrences html, as the these tags are not supported in Type-definitions
+                    .replace(/<[^>]*>/gm, '')
+                // replacing @link tags with the object namepath to which it was linked,
+                // as these link tags are not navigable in type-definitions.
+                    .replace(/\{@link (\w*)[#.]+(\w*)\}/gm, '$1.$2')
+                    .replace(/\{@link (\S+)\}/gm, '$1'); // remove @link tags
+
+                source = `${templates.heading}\n\n${templates.postmanLegacyString}\n\n${source}`;
+
+                const node = typescript.createSourceFile(
+                        '../types/sandbox/index.d.ts',
+                        source,
+                        typescript.ScriptTarget.Latest
+                    ),
+
+                    printer = typescript.createPrinter({
+                        removeComments: false,
+                        newLine: typescript.NewLineKind.LineFeed
+                    });
+
+                testScriptSource = generateTestScriptSource(node, printer);
+                preScriptSource = generatePreScriptSource(node, printer);
+
+                files = [{fileName: `${TARGET_DIR}/pre-script-sandbox-api.d.ts`, content: preScriptSource},
+                    {fileName: `${TARGET_DIR}/tests-sandbox-api.d.ts`, content: testScriptSource}];
+
+                async.each(files, function (file, callback) {
+                    fs.writeFile(file.fileName, file.content, function (err) {
+                        if (err) {
+                            console.log(chalk.red.bold(`unable to write ${file.fileName} file'`));
+                        }
+                        else {
+                            console.log(
+                                chalk.green.bold(`${file.fileName} file saved successfully at "${TARGET_DIR}"`));
+                        }
+
+                        callback();
+                    });
+
+                }, function (err) {
+                    if (err) {
+                        console.log(chalk.red.bold('couldn\'t save all type-definitions. Aborting...'));
+                        exit(1);
+                    }
+                    else {
+                        console.log(chalk.green.bold('All type-definition files have been processed successfully'));
+                        console.log(chalk.yellow.bold('Deleting index.d.ts files'));
+                        fs.unlink(`${TARGET_DIR}/index.d.ts`, function (err) {
+                            if (err) {
+                                console.log(chalk.red.bold('couldn\'t delete index.d.ts file. Aborting...'));
+                                exit(1);
+                            }
+                            else {
+                                console.log(
+                                    chalk.green.bold(`sandbox type-definition files available at ${TARGET_DIR}`));
+                                exit(0);
+                            }
+                        });
+                    }
+                });
+            });
+        }
+        else {
+            // output status
+            console.log(chalk.red.bold('unable to generate type-definition'));
+            exit(code);
+        }
+    });
+};
+
+// ensure we run this script exports if this is a direct stdin.tty run
+!module.parent && module.exports(exit);

--- a/npm/build-types.js
+++ b/npm/build-types.js
@@ -8,7 +8,6 @@ require('shelljs/global');
 
 var path = require('path'),
     fs = require('fs'),
-    pkg = require('../package.json'),
     chalk = require('chalk'),
     templates = require('./utils/templates'),
 

--- a/npm/build-types.js
+++ b/npm/build-types.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// ---------------------------------------------------------------------------------------------------------------------
+// This script is intended to generate type-definition for this module
+// ---------------------------------------------------------------------------------------------------------------------
+
+/* eslint-env node, es6 */
+require('shelljs/global');
+
+var path = require('path'),
+    fs = require('fs'),
+    pkg = require('../package.json'),
+    chalk = require('chalk'),
+    templates = require('./utils/templates'),
+
+
+    IS_WINDOWS = (/^win/).test(process.platform),
+    TARGET_DIR = path.join('types');
+
+module.exports = function (exit) {
+    console.log(chalk.yellow.bold('Generating type-definitions...'));
+
+    try {
+        // clean directory
+        test('-d', TARGET_DIR) && rm('-rf', TARGET_DIR);
+    }
+    catch (e) {
+        console.error(e.stack || e);
+        return exit(e ? 1 : 0);
+    }
+
+    exec(`${IS_WINDOWS ? '' : 'node'} ${path.join('node_modules', '.bin', 'jsdoc')}${IS_WINDOWS ? '.cmd' : ''}` +
+        ' -c .jsdoc-config-type-def.json -p', function (code) {
+
+        if (!code) {
+            fs.readFile(`${TARGET_DIR}/index.d.ts`, function (err, contents) {
+                if (err) {
+                    console.log(chalk.red.bold('unable to read the type-definition file'));
+                    exit(1);
+                }
+                var source = contents.toString();
+                source = source
+                    // replacing Integer with number as 'Integer' is not a valid data-type in Typescript
+                    .replace(/Integer/gm, 'number')
+                    // replacing String[] with string[] as 'String' is not a valid data-type in Typescript
+                    .replace(/String\[]/gm, 'string[]')
+                    // replacing Boolean[] with boolean[] as 'Boolean' is not a valid data-type in Typescript
+                    .replace(/Boolean\[]/gm, 'boolean[]')
+                    // removing all occurrences html, as the these tags are not supported in Type-definitions
+                    .replace(/<[^>]*>/gm, '')
+                    // replacing @link tags with the object namepath to which it was linked,
+                    // as these link tags are not navigable in type-definitions.
+                    .replace(/\{@link (\w*)[#.]+(\w*)\}/gm, '$1.$2')
+                    .replace(/\{@link (\S+)\}/gm, '$1'); // remove @link tags
+
+                source = `${templates.heading}\n${source}`;
+
+                fs.writeFile(`${TARGET_DIR}/index.d.ts`, source, function (err) {
+                    if (err) {
+                        console.log(chalk.red.bold('unable to write the type-definition file'));
+                        exit(1);
+                    }
+                    console.log(chalk.green.bold(`type-definition file saved successfully at "${TARGET_DIR}"`));
+                    exit(0);
+                });
+            });
+        }
+        else {
+            // output status
+            console.log(chalk.red.bold('unable to generate type-definition'));
+            exit(code);
+        }
+    });
+};
+
+// ensure we run this script exports if this is a direct stdin.tty run
+!module.parent && module.exports(exit);

--- a/npm/utils/templates.js
+++ b/npm/utils/templates.js
@@ -1,0 +1,160 @@
+var pkg = require('../../package.json'),
+
+    heading =
+`// Type definitions for postman-sandbox ${pkg.version}
+// Project: https://github.com/postmanlabs/postman-collection
+// Definitions by: PostmanLabs
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+/// <reference types="node" />
+`,
+
+    postmanLegacyString =
+`declare var postman: PostmanLegacy;
+
+declare interface PostmanLegacy {
+
+  /***
+   * Sets the next request to be executed.
+   * @param requestName Name of the next request to be executed.
+   */
+  setNextRequest(requestName: string): void
+}`,
+
+    postmanExtensionString =
+`interface Postman {
+    test: Test;
+}
+
+interface Test {
+
+    /**
+     * You can use this function to write test specifications inside either the Pre-request Script or Tests sandbox.
+     * Writing tests inside this function allows you to name the test accurately and this function also ensures the
+     * rest of the script is not blocked even if there are errors inside the function.
+     * @param testName
+     * @param specFunction
+     */
+    (testName: string, specFunction: Function): void
+  
+    /**
+     * Get the total number tests from a specific location.
+     */
+    index(): number
+  }
+`,
+
+    cookieListExtensionString =
+`interface CookieList {
+jar() : PostmanCookieJar
+}`,
+    responseExtensionString =
+`
+interface Response extends Assertable {
+
+}
+
+interface Assertable {
+  to: {
+    have: AssertableHave
+    /**
+     * The properties inside the "pm.response.to.be" object allows you to easily assert a set of pre-defined rules.
+     */
+    be: AssertableBe
+  }
+}
+
+interface AssertableHave {
+  status(code: number): any
+  status(reason: string): any
+  header(key: string): any
+  header(key: string, optionalValue: string): any
+  body(): any
+  body(optionalStringValue: string): any
+  body(optionalRegExpValue: RegExp): any
+  jsonBody(): any
+  jsonBody(optionalExpectEqual: object): any
+  jsonBody(optionalExpectPath: string): any
+  jsonBody(optionalExpectPath: string, optionalValue: any): any
+  jsonSchema(schema: object): any
+  jsonSchema(schema: object, ajvOptions: object): any
+}
+
+interface AssertableBe {
+
+  /**
+   * Checks 1XX status code
+   */
+  info: number
+
+  /**
+   * Checks 2XX status code
+   */
+  success: number
+
+  /**
+   * Checks 3XX status code
+   */
+  redirection: number
+
+  /**
+   * Checks 4XX status code
+   */
+  clientError: number
+
+  /**
+   * Checks 5XX
+   */
+  serverError: number
+
+  /**
+   * Checks 4XX or 5XX
+   */
+  error: number
+
+  /**
+   * Status code must be 200
+   */
+  ok: number
+
+  /**
+   * Status code must be 202
+   */
+  accepted: number
+
+  /**
+   * Status code must be 400
+   */
+  badRequest: number
+
+  /**
+   * Status code must be 401
+   */
+  unauthorized: number
+
+  /**
+   * Status code 403
+   */
+  forbidden: number
+
+  /**
+   * Status code of response is checked to be 404
+   */
+  notFound: number
+
+  /**
+   * Checks whether response status code is 429
+   */
+  rateLimited: number
+}
+`;
+
+module.exports = {
+    heading: heading,
+    postmanLegacyString: postmanLegacyString,
+    postmanExtensionString: postmanExtensionString,
+    cookieListExtensionString: cookieListExtensionString,
+    responseExtensionString: responseExtensionString
+};
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -636,7 +636,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
@@ -1769,7 +1769,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
           "dev": true
         }
@@ -2057,7 +2057,7 @@
         },
         "source-map": {
           "version": "0.2.0",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
           "optional": true,
@@ -3859,7 +3859,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -3906,7 +3906,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -4132,7 +4132,7 @@
         },
         "resolve": {
           "version": "1.1.7",
-          "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         },
@@ -4869,7 +4869,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -4926,7 +4926,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -4935,7 +4935,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -5384,7 +5384,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
@@ -5450,7 +5450,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -5918,7 +5918,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -7203,6 +7203,15 @@
         }
       }
     },
+    "tsd-jsdoc": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tsd-jsdoc/-/tsd-jsdoc-2.5.0.tgz",
+      "integrity": "sha512-80fcJLAiUeerg4xPftp+iEEKWUjJjHk9AvcHwJqA8Zw0R4oASdu3kT/plE/Zj19QUTz8KupyOX25zStlNJjS9g==",
+      "dev": true,
+      "requires": {
+        "typescript": "^3.2.1"
+      }
+    },
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
@@ -7250,6 +7259,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   },
   "scripts": {
     "cache": "node npm/cache.js $1",
+    "build-common-types": "node npm/build-types.js",
+    "build-sandbox-types": "node npm/build-sandbox-types.js",
+    "build-types": "npm run build-common-types && npm run build-sandbox-types",
     "test-browser": "node npm/test-browser.js",
     "test-integration": "node npm/test-integration.js",
     "test-system": "node npm/test-system.js",
@@ -79,6 +82,7 @@
     "shelljs": "0.8.4",
     "sinon": "8.1.1",
     "sinon-chai": "3.5.0",
+    "tsd-jsdoc": "2.5.0",
     "tv4": "1.3.0",
     "uglifyify": "5.0.2",
     "uniscope": "1.1.3",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,255 @@
+// Type definitions for postman-sandbox 3.5.7
+// Project: https://github.com/postmanlabs/postman-collection
+// Definitions by: PostmanLabs
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+/// <reference types="node" />
+
+declare const CONSOLE_EVENT_BASE = "execution.console.";
+
+/**
+ * List of functions that we expect and create for console
+ */
+declare const logLevels: string[];
+
+/**
+ * Replacer to be used with teleport-javascript to handle cases which are not
+ * handled by it.
+ * @param key - Key of the property to replace
+ * @param value - Value of property to replace
+ * @returns Replaced value
+ */
+declare function replacer(key: string, value: any): any;
+
+/**
+ * Convert PostmanCookie Cookie instance to ToughCookie instance.
+ * @param cookie - Postman Cookie instance
+ * @returns Tough Cookie instance
+ */
+declare function serialize(cookie: PostmanCookie): ToughCookie;
+
+/**
+ * Convert Tough Cookie instance to Electron Cookie instance.
+ * @param cookie - Tough Cookie instance
+ * @returns Electron Cookie instance
+ */
+declare function deserialize(cookie: ToughCookie): ElectronCookie;
+
+/**
+ * Sanitize url object or string to Postman Url instance.
+ */
+declare function sanitizeURL(url: any | string): Url | null;
+
+/**
+ * Executes a provided function once for each array element.
+ * @param items - Array of items to iterate over
+ * @param fn - An async function to apply to each item in items
+ * @param cb - A callback which is called when all iteratee functions have finished,
+ * or an error occurs
+ */
+declare function forEachWithCallback(items: any[], fn: (...params: any[]) => any, cb: (...params: any[]) => any): void;
+
+/**
+ * Helper function to handle callback.
+ * @param callback - Callback function
+ * @param err - Error or Error message
+ */
+declare function callbackHandler(callback: (...params: any[]) => any, err: Error | string, result: any): void;
+
+declare interface PostmanCookieJar {
+    /**
+     * Get the cookie value with the given name.
+     */
+    get(url: string, name: string, callback: (...params: any[]) => any): void;
+    /**
+     * Get all the cookies for the given URL.
+     */
+    getAll(url: string, options?: any, callback: (...params: any[]) => any): void;
+    /**
+     * Set or update a cookie.
+     */
+    set(url: string, name: string | any, value?: string | ((...params: any[]) => any), callback?: (...params: any[]) => any): void;
+    /**
+     * Remove single cookie with the given name.
+     */
+    unset(url: string, name: string, callback?: (...params: any[]) => any): void;
+    /**
+     * Remove all the cookies for the given URL.
+     */
+    clear(url: string, callback?: (...params: any[]) => any): void;
+}
+
+/**
+ * The pm object encloses all information pertaining to the script being executed and
+ * allows one to access a copy of the request being sent or the response received.
+ * It also allows one to get and set environment and global variables.
+ */
+declare var pm: Postman;
+
+declare var request: any;
+
+declare var response: any;
+
+/**
+ * @property async - true if the executed script was async, false otherwise
+ * @property visualizer - visualizer data
+ * @property nextRequest - next request to send
+ */
+declare type Return = {
+    async: boolean;
+    visualizer: Visualizer;
+    nextRequest: any;
+};
+
+/**
+ * Use this function to assign readonly properties to an object
+ */
+declare function _assignDefinedReadonly(obj: any, properties: any): void;
+
+declare class Postman {
+    constructor(bridge: EventEmitter, execution: Execution, onRequest: (...params: any[]) => any, cookieStore: any);
+    /**
+     * The pm.info object contains information pertaining to the script being executed.
+     * Useful information such as the request name, request Id, and iteration count are
+     * stored inside of this object.
+     */
+    info: Info;
+    globals: VariableScope;
+    environment: VariableScope;
+    collectionVariables: VariableScope;
+    variables: VariableScope;
+    /**
+     * The iterationData object contains data from the data file provided during a collection run.
+     */
+    iterationData: VariableScope;
+    /**
+     * The request object inside pm is a representation of the request for which this script is being run.
+     * For a pre-request script, this is the request that is about to be sent and when in a test script,
+     * this is the representation of the request that was sent.
+     */
+    request: Request;
+    /**
+     * Inside the test scripts, the pm.response object contains all information pertaining
+     * to the response that was received.
+     */
+    response: Response;
+    /**
+     * The cookies object contains a list of cookies that are associated with the domain
+     * to which the request was made.
+     */
+    cookies: CookieList;
+    visualizer: Visualizer;
+    /**
+     * Allows one to send request from script asynchronously.
+     */
+    sendRequest(req: Request | string, callback: (...params: any[]) => any): void;
+    expect: Chai.ExpectStatic;
+}
+
+/**
+ * Contains information pertaining to the script execution
+ */
+declare interface Info {
+    /**
+     * Contains information whether the script being executed is a "prerequest" or a "test" script.
+     */
+    eventName: string;
+    /**
+     * Is the value of the current iteration being run.
+     */
+    iteration: number;
+    /**
+     * Is the total number of iterations that are scheduled to run.
+     */
+    iterationCount: number;
+    /**
+     * The saved name of the individual request being run.
+     */
+    requestName: string;
+    /**
+     * The unique guid that identifies the request being run.
+     */
+    requestId: string;
+}
+
+declare interface Visualizer {
+    /**
+     * Set visualizer template and its options
+     * @param template - visualisation layout in form of template
+     * @param [data] - data object to be used in template
+     * @param [options] - options to use while processing the template
+     */
+    set(template: string, data?: any, options?: any): void;
+    /**
+     * Clear all visualizer data
+     */
+    clear(): void;
+}
+
+/**
+ * Different modes for a request body.
+ */
+declare enum REQUEST_MODES {
+    RAW = "raw",
+    URLENCODED = "urlencoded",
+    FORMDATA = "formdata",
+    FILE = "file"
+}
+
+/**
+ * Raises a single assertion event with an array of assertions from legacy `tests` object.
+ */
+declare function raiseAssertionEvent(scope: Uniscope, execution: Execution, pmapi: any): void;
+
+declare class PostmanLegacyInterface {
+    constructor(options: any);
+}
+
+declare class PostmanLegacyTestInterface extends PostmanLegacyInterface {
+    constructor(options: any);
+}
+
+declare function getResponseCookie(cookieName: string): any;
+
+declare function getResponseHeader(headerName: string): string;
+
+declare var SandboxGlobals: any;
+
+/**
+ * The set of timer function names. We use this array to define common behaviour of all setters and clearer timer
+ * functions
+ */
+declare const timerFunctionNames: string[];
+
+/**
+ * This object defines a set of timer function names that are trigerred a number of times instead of a single time.
+ * Such timers, when placed in generic rules, needs special attention.
+ */
+declare const multiFireTimerFunctions: boolean[];
+
+/**
+ * This object defines a set of function timer names that do not fire based on any pre-set duration or interval.
+ * Such timers, when placed in generic rules, needs special attention.
+ */
+declare const staticTimerFunctions: boolean[];
+
+/**
+ * A local copy of Slice function of Array
+ */
+declare const arrayProtoSlice: (...params: any[]) => any;
+
+/**
+ * This object holds the current global timers
+ */
+declare var defaultTimers: any;
+
+declare class Timerz {
+    constructor(delegations?: any, onError?: (...params: any[]) => any, onAnyTimerStart?: (...params: any[]) => any, onAllTimerEnd?: (...params: any[]) => any);
+    /**
+     * Holds the present timers, either delegated or defaults
+     */
+    timers: any;
+}
+
+declare const xml2jsOptions: any;
+

--- a/types/sandbox/pre-script-sandbox-api.d.ts
+++ b/types/sandbox/pre-script-sandbox-api.d.ts
@@ -1,0 +1,95 @@
+// Type definitions for postman-sandbox 3.5.7
+// Project: https://github.com/postmanlabs/postman-collection
+// Definitions by: PostmanLabs
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+/// <reference types="node" />
+declare var postman: PostmanLegacy;
+
+declare interface PostmanLegacy {
+    /***
+     * Sets the next request to be executed.
+     * @param requestName Name of the next request to be executed.
+     */
+    setNextRequest(requestName: string): void;
+}
+
+declare class Postman {
+    constructor(bridge: EventEmitter, execution: Execution, onRequest: (...params: any[]) => any, cookieStore: any);
+    /**
+     * The pm.info object contains information pertaining to the script being executed.
+     * Useful information such as the request name, request Id, and iteration count are
+     * stored inside of this object.
+     */
+    info: Info;
+    globals: VariableScope;
+    environment: VariableScope;
+    collectionVariables: VariableScope;
+    variables: VariableScope;
+    /**
+     * The request object inside pm is a representation of the request for which this script is being run.
+     * For a pre-request script, this is the request that is about to be sent and when in a test script,
+     * this is the representation of the request that was sent.
+     */
+    request: Request;
+    /**
+     * Allows one to send request from script asynchronously.
+     */
+    sendRequest(req: Request | string, callback: (...params: any[]) => any): void;
+}
+
+/**
+ * Contains information pertaining to the script execution
+ */
+declare interface Info {
+    /**
+     * Contains information whether the script being executed is a "prerequest" or a "test" script.
+     */
+    eventName: string;
+    /**
+     * Is the value of the current iteration being run.
+     */
+    iteration: number;
+    /**
+     * Is the total number of iterations that are scheduled to run.
+     */
+    iterationCount: number;
+    /**
+     * The saved name of the individual request being run.
+     */
+    requestName: string;
+    /**
+     * The unique guid that identifies the request being run.
+     */
+    requestId: string;
+}
+
+/**
+ * The pm object encloses all information pertaining to the script being executed and
+ * allows one to access a copy of the request being sent or the response received.
+ * It also allows one to get and set environment and global variables.
+ */
+declare var pm: Postman;
+
+interface Postman {
+    test: Test;
+}
+
+interface Test {
+
+    /**
+     * You can use this function to write test specifications inside either the Pre-request Script or Tests sandbox.
+     * Writing tests inside this function allows you to name the test accurately and this function also ensures the
+     * rest of the script is not blocked even if there are errors inside the function.
+     * @param testName
+     * @param specFunction
+     */
+    (testName: string, specFunction: Function): void
+  
+    /**
+     * Get the total number tests from a specific location.
+     */
+    index(): number
+  }
+
+

--- a/types/sandbox/tests-sandbox-api.d.ts
+++ b/types/sandbox/tests-sandbox-api.d.ts
@@ -1,0 +1,252 @@
+// Type definitions for postman-sandbox 3.5.7
+// Project: https://github.com/postmanlabs/postman-collection
+// Definitions by: PostmanLabs
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+/// <reference types="node" />
+declare var postman: PostmanLegacy;
+
+declare interface PostmanLegacy {
+    /***
+     * Sets the next request to be executed.
+     * @param requestName Name of the next request to be executed.
+     */
+    setNextRequest(requestName: string): void;
+}
+
+declare class Postman {
+    constructor(bridge: EventEmitter, execution: Execution, onRequest: (...params: any[]) => any, cookieStore: any);
+    /**
+     * The pm.info object contains information pertaining to the script being executed.
+     * Useful information such as the request name, request Id, and iteration count are
+     * stored inside of this object.
+     */
+    info: Info;
+    globals: VariableScope;
+    environment: VariableScope;
+    collectionVariables: VariableScope;
+    variables: VariableScope;
+    /**
+     * The iterationData object contains data from the data file provided during a collection run.
+     */
+    iterationData: VariableScope;
+    /**
+     * The request object inside pm is a representation of the request for which this script is being run.
+     * For a pre-request script, this is the request that is about to be sent and when in a test script,
+     * this is the representation of the request that was sent.
+     */
+    request: Request;
+    /**
+     * Inside the test scripts, the pm.response object contains all information pertaining
+     * to the response that was received.
+     */
+    response: Response;
+    /**
+     * The cookies object contains a list of cookies that are associated with the domain
+     * to which the request was made.
+     */
+    cookies: CookieList;
+    visualizer: Visualizer;
+    /**
+     * Allows one to send request from script asynchronously.
+     */
+    sendRequest(req: Request | string, callback: (...params: any[]) => any): void;
+    expect: Chai.ExpectStatic;
+}
+
+/**
+ * Contains information pertaining to the script execution
+ */
+declare interface Info {
+    /**
+     * Contains information whether the script being executed is a "prerequest" or a "test" script.
+     */
+    eventName: string;
+    /**
+     * Is the value of the current iteration being run.
+     */
+    iteration: number;
+    /**
+     * Is the total number of iterations that are scheduled to run.
+     */
+    iterationCount: number;
+    /**
+     * The saved name of the individual request being run.
+     */
+    requestName: string;
+    /**
+     * The unique guid that identifies the request being run.
+     */
+    requestId: string;
+}
+
+declare interface Visualizer {
+    /**
+     * Set visualizer template and its options
+     * @param template - visualisation layout in form of template
+     * @param [data] - data object to be used in template
+     * @param [options] - options to use while processing the template
+     */
+    set(template: string, data?: any, options?: any): void;
+    /**
+     * Clear all visualizer data
+     */
+    clear(): void;
+}
+
+/**
+ * The pm object encloses all information pertaining to the script being executed and
+ * allows one to access a copy of the request being sent or the response received.
+ * It also allows one to get and set environment and global variables.
+ */
+declare var pm: Postman;
+
+declare interface PostmanCookieJar {
+    /**
+     * Get the cookie value with the given name.
+     */
+    get(url: string, name: string, callback: (...params: any[]) => any): void;
+    /**
+     * Get all the cookies for the given URL.
+     */
+    getAll(url: string, options?: any, callback: (...params: any[]) => any): void;
+    /**
+     * Set or update a cookie.
+     */
+    set(url: string, name: string | any, value?: string | ((...params: any[]) => any), callback?: (...params: any[]) => any): void;
+    /**
+     * Remove single cookie with the given name.
+     */
+    unset(url: string, name: string, callback?: (...params: any[]) => any): void;
+    /**
+     * Remove all the cookies for the given URL.
+     */
+    clear(url: string, callback?: (...params: any[]) => any): void;
+}
+
+
+
+interface Postman {
+    test: Test;
+}
+
+interface Test {
+
+    /**
+     * You can use this function to write test specifications inside either the Pre-request Script or Tests sandbox.
+     * Writing tests inside this function allows you to name the test accurately and this function also ensures the
+     * rest of the script is not blocked even if there are errors inside the function.
+     * @param testName
+     * @param specFunction
+     */
+    (testName: string, specFunction: Function): void
+  
+    /**
+     * Get the total number tests from a specific location.
+     */
+    index(): number
+  }
+
+
+interface CookieList {
+jar() : PostmanCookieJar
+}
+
+
+interface Response extends Assertable {
+
+}
+
+interface Assertable {
+  to: {
+    have: AssertableHave
+    /**
+     * The properties inside the "pm.response.to.be" object allows you to easily assert a set of pre-defined rules.
+     */
+    be: AssertableBe
+  }
+}
+
+interface AssertableHave {
+  status(code: number): any
+  status(reason: string): any
+  header(key: string): any
+  header(key: string, optionalValue: string): any
+  body(): any
+  body(optionalStringValue: string): any
+  body(optionalRegExpValue: RegExp): any
+  jsonBody(): any
+  jsonBody(optionalExpectEqual: object): any
+  jsonBody(optionalExpectPath: string): any
+  jsonBody(optionalExpectPath: string, optionalValue: any): any
+  jsonSchema(schema: object): any
+  jsonSchema(schema: object, ajvOptions: object): any
+}
+
+interface AssertableBe {
+
+  /**
+   * Checks 1XX status code
+   */
+  info: number
+
+  /**
+   * Checks 2XX status code
+   */
+  success: number
+
+  /**
+   * Checks 3XX status code
+   */
+  redirection: number
+
+  /**
+   * Checks 4XX status code
+   */
+  clientError: number
+
+  /**
+   * Checks 5XX
+   */
+  serverError: number
+
+  /**
+   * Checks 4XX or 5XX
+   */
+  error: number
+
+  /**
+   * Status code must be 200
+   */
+  ok: number
+
+  /**
+   * Status code must be 202
+   */
+  accepted: number
+
+  /**
+   * Status code must be 400
+   */
+  badRequest: number
+
+  /**
+   * Status code must be 401
+   */
+  unauthorized: number
+
+  /**
+   * Status code 403
+   */
+  forbidden: number
+
+  /**
+   * Status code of response is checked to be 404
+   */
+  notFound: number
+
+  /**
+   * Checks whether response status code is 429
+   */
+  rateLimited: number
+}


### PR DESCRIPTION
Requirement: Auto-generate type-definitions files from the existing `jsDoc` comments.

Implementation:
1. Added `jsDoc` config file to generate library-wide type-definiton file under `types`.
2. Added `jsDoc` config file to generate type-definitions files to used by the `postman-app` under `types\sandbox`.
3. Added script to manipulate the type-definition file generate under `types\sandbox` and create two different files for `pre-script` and `script` editors. 