### PR TITLE
Destroy the bridge once we get there 💣

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+master:
+  fixed bugs:
+    - GH-603 Removed access from the UVM bridge once it's in execution closure
+
 3.5.9:
   date: 2020-08-31
   chores:

--- a/lib/sandbox/execute-context.js
+++ b/lib/sandbox/execute-context.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
         '\'use sandbox2\';': true
     };
 
-module.exports = function (scope, code, execution, console, timers, pmapi) {
+module.exports = function (scope, code, execution, console, timers, pmapi, onAssertion) {
     // if there is no code, then no point bubbling anything up
     if (!(code && _.isString(code))) {
         return timers.terminate();
@@ -53,7 +53,7 @@ module.exports = function (scope, code, execution, console, timers, pmapi) {
         execution.return.async = (timers.queueLength() > 0);
 
         // call this hook to perform any post script execution tasks
-        legacy.finish(scope, execution, pmapi);
+        legacy.finish(scope, pmapi, onAssertion);
 
         // if timers are running, we do not need to proceed with any logic of completing execution. instead we wait
         // for timer completion callback to fire

--- a/lib/sandbox/execute.js
+++ b/lib/sandbox/execute.js
@@ -14,6 +14,8 @@ var _ = require('lodash'),
     EXECUTION_ABORT_EVENT_BASE = 'execution.abort.',
     EXECUTION_RESPONSE_EVENT_BASE = 'execution.response.',
     EXECUTION_COOKIES_EVENT_BASE = 'execution.cookies.',
+    EXECUTION_ASSERTION_EVENT = 'execution.assertion',
+    EXECUTION_ASSERTION_EVENT_BASE = 'execution.assertion.',
 
     executeContext = require('./execute-context');
 
@@ -53,12 +55,20 @@ module.exports = function (bridge, glob) {
             abortEventName = EXECUTION_ABORT_EVENT_BASE + id,
             responseEventName = EXECUTION_RESPONSE_EVENT_BASE + id,
             cookiesEventName = EXECUTION_COOKIES_EVENT_BASE + id,
+            assertionEventName = EXECUTION_ASSERTION_EVENT_BASE + id,
 
             // extract the code from event. The event can be the code itself and we know that if the event is of type
             // string.
             code = _.isFunction(event.script && event.script.toSource) && event.script.toSource(),
             // create the execution object
             execution = new Execution(id, event, context, options),
+
+            dispatchAssertions = function (assertions) {
+                !Array.isArray(assertions) && (assertions = [assertions]);
+
+                bridge.dispatch(assertionEventName, options.cursor, assertions);
+                bridge.dispatch(EXECUTION_ASSERTION_EVENT, options.cursor, assertions);
+            },
 
             waiting,
             timers;
@@ -125,9 +135,13 @@ module.exports = function (bridge, glob) {
             // inside this closure.
             (new PostmanConsole(bridge, id, options.cursor, options.debug && glob.console)),
             timers,
-            (new PostmanAPI(bridge, execution, function (request, callback) {
-                var eventId = timers.setEvent(callback);
-                bridge.dispatch(executionRequestEventName, options.cursor, id, eventId, request);
-            }, new PostmanCookieStore(id, bridge, timers))));
+            (
+                new PostmanAPI(execution, function (request, callback) {
+                    var eventId = timers.setEvent(callback);
+                    bridge.dispatch(executionRequestEventName, options.cursor, id, eventId, request);
+                }, dispatchAssertions, new PostmanCookieStore(id, bridge, timers))
+            ),
+            dispatchAssertions
+        );
     });
 };

--- a/lib/sandbox/execute.js
+++ b/lib/sandbox/execute.js
@@ -63,7 +63,22 @@ module.exports = function (bridge, glob) {
             // create the execution object
             execution = new Execution(id, event, context, options),
 
+            /**
+             * Dispatch assertions from `pm.test` or legacy `test` API.
+             *
+             * @private
+             * @param {Object[]} assertions
+             * @param {String} assertions[].name
+             * @param {Number} assertions[].index
+             * @param {Object} assertions[].error
+             * @param {Boolean} assertions[].async
+             * @param {Boolean} assertions[].passed
+             * @param {Boolean} assertions[].skipped
+             */
             dispatchAssertions = function (assertions) {
+                // Legacy `test` API accumulates all the assertions and dispatches at once
+                // whereas, `pm.test` dispatch on every single assertion.
+                // For compatibility, dispatch the single assertion as an array.
                 !Array.isArray(assertions) && (assertions = [assertions]);
 
                 bridge.dispatch(assertionEventName, options.cursor, assertions);

--- a/lib/sandbox/index.js
+++ b/lib/sandbox/index.js
@@ -34,3 +34,7 @@ require('./execute')(bridge, {
     console: (typeof console !== 'undefined' ? console : null),
     window: (typeof window !== 'undefined' ? window : null)
 });
+
+// We don't need direct access to the global bridge once it's part of execution closure.
+// eslint-disable-next-line no-global-assign, no-implicit-globals, no-delete-var
+bridge = null; delete bridge;

--- a/lib/sandbox/index.js
+++ b/lib/sandbox/index.js
@@ -37,4 +37,4 @@ require('./execute')(bridge, {
 
 // We don't need direct access to the global bridge once it's part of execution closure.
 // eslint-disable-next-line no-global-assign, no-implicit-globals, no-delete-var
-bridge = null; delete bridge;
+bridge = undefined; delete bridge;

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -1,7 +1,4 @@
-var EXECUTION_ASSERTION_EVENT = 'execution.assertion',
-    EXECUTION_ASSERTION_EVENT_BASE = 'execution.assertion.',
-
-    _ = require('lodash'),
+var _ = require('lodash'),
     Ajv = require('ajv'),
     sdk = require('postman-collection'),
     PostmanCookieJar = require('./cookie-jar'),
@@ -42,17 +39,14 @@ var EXECUTION_ASSERTION_EVENT = 'execution.assertion',
 /**
  * @constructor
  *
- * @param {EventEmitter} bridge
  * @param {Execution} execution
  * @param {Function} onRequest
+ * @param {Function} onAssertion
  * @param {Object} cookieStore
  */
-Postman = function Postman (bridge, execution, onRequest, cookieStore) {
-    var assertionEventName = EXECUTION_ASSERTION_EVENT_BASE + execution.id, // we keep this prepared for repeat use
-        iterationData;
-
+Postman = function Postman (execution, onRequest, onAssertion, cookieStore) {
     // @todo - ensure runtime passes data in a scope format
-    iterationData = new VariableScope();
+    var iterationData = new VariableScope();
     iterationData.syncVariablesFrom(execution.data);
 
     // instead of creating new instance of variableScope,
@@ -216,10 +210,7 @@ Postman = function Postman (bridge, execution, onRequest, cookieStore) {
     });
 
     // extend pm api with test runner abilities
-    setupTestRunner(this, function (assertion) {
-        bridge.dispatch(assertionEventName, execution.cursor, [assertion]);
-        bridge.dispatch(EXECUTION_ASSERTION_EVENT, execution.cursor, [assertion]);
-    });
+    setupTestRunner(this, onAssertion);
 
     // add response assertions
     if (this.response) {

--- a/lib/sandbox/postman-legacy-interface.js
+++ b/lib/sandbox/postman-legacy-interface.js
@@ -20,8 +20,6 @@ var _ = require('lodash'),
         'JSON', '_', 'CryptoJS', 'atob', 'btoa', 'tv4', 'xml2Json', 'Backbone', 'cheerio'
     ],
 
-    EXECUTION_ASSERTION_EVENT = 'execution.assertion',
-    EXECUTION_ASSERTION_EVENT_BASE = 'execution.assertion.',
     E = '',
     FUNCTION = 'function',
     TARGET_TEST = 'test',
@@ -117,13 +115,12 @@ getRequestBody = function (request) {
 /**
  * Raises a single assertion event with an array of assertions from legacy `tests` object.
  * @param  {Uniscope} scope
- * @param  {Execution} execution
  * @param  {Object} pmapi
+ * @param  {Function} onAssertion
  */
-raiseAssertionEvent = function (scope, execution, pmapi) {
+raiseAssertionEvent = function (scope, pmapi, onAssertion) {
     var tests = scope._imports && scope._imports.tests,
         assertionIndex = pmapi.test.index(),
-        assertionEventName = EXECUTION_ASSERTION_EVENT_BASE + execution.id,
         assertions;
 
     if (_.isEmpty(tests)) {
@@ -152,8 +149,7 @@ raiseAssertionEvent = function (scope, execution, pmapi) {
         };
     });
 
-    bridge.dispatch(assertionEventName, execution.cursor, assertions);
-    bridge.dispatch(EXECUTION_ASSERTION_EVENT, execution.cursor, assertions);
+    onAssertion(assertions);
 };
 
 /**
@@ -404,14 +400,14 @@ module.exports = {
      * This is the place where we should put all the tasks
      * that need to be executed after the completion of script execution
      * @param  {Uniscope} scope
-     * @param  {Execution} exection
      * @param  {Object} pmapi
+     * @param  {Function} onAssertion
      */
-    finish: function (scope, execution, pmapi) {
+    finish: function (scope, pmapi, onAssertion) {
         if (!scope.__postman_legacy_setup) {
             return;
         }
 
-        raiseAssertionEvent(scope, execution, pmapi);
+        raiseAssertionEvent(scope, pmapi, onAssertion);
     }
 };

--- a/test/unit/execution.test.js
+++ b/test/unit/execution.test.js
@@ -12,7 +12,7 @@ var _ = require('lodash'),
 describe('execution', function () {
     before(function () {
         execution = new Execution('id', {listen: 'test'}, {}, {});
-        pm = new pmAPI({}, execution, _.noop);
+        pm = new pmAPI(execution, _.noop, _.noop);
     });
 
     it('can be serialized', function () {

--- a/test/unit/sandbox-sanity.test.js
+++ b/test/unit/sandbox-sanity.test.js
@@ -43,6 +43,20 @@ describe('sandbox', function () {
         });
     });
 
+    it('should not have access to uvm bridge', function (done) {
+        Sandbox.createContext(function (err, ctx) {
+            if (err) { return done(err); }
+            ctx.on('error', done);
+
+            ctx.execute(`
+                var assert = require('assert');
+                assert.equal(typeof bridge, 'undefined');
+                assert.equal(typeof this.bridge, 'undefined');
+                assert.equal(typeof Function('return this.bridge')(), 'undefined');
+            `, done);
+        });
+    });
+
     it('should accept an external execution id', function (done) {
         Sandbox.createContext(function (err, ctx) {
             if (err) { return done(err); }


### PR DESCRIPTION
Makes sure UVM's communication bridge is not accessible in the global scope after we setup the execution context.