### PR TITLE
Replaced uglifyify with terser for bootcode compression

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -6,6 +6,7 @@ master:
     - GH-605 Sanitized the global scope by deleting the forbidden properties
   chores:
     - GH-609 Bumped uvm (Web Worker bridge) and uniscope dependency
+    - GH-615 Used terser for bootcode compression and store as utf8 code string
     - GH-613 Converted internal function implementations to ES6 class
     - GH-613 Removed uuid and inherits dependencies
     - >-

--- a/lib/bootcode.js
+++ b/lib/bootcode.js
@@ -38,7 +38,6 @@ cacher = function (done) {
             cache = code;
             cacher.cached = true; // a flag to aid debugging
         }
-        code && _.isString(code) && (cache = code);
 
         return done(null, cache);
     });

--- a/lib/bundle/index.js
+++ b/lib/bundle/index.js
@@ -1,15 +1,9 @@
 const _ = require('lodash'),
+    { minify } = require('terser'),
+
     bundlingOptions = require('./bundling-options'),
 
     PREFER_BUILTIN = 'preferBuiltin',
-
-    defaultCompressOptions = {
-        transformer: 'uglifyify',
-        options: {
-            output: { ascii_only: true },
-            global: true
-        }
-    },
 
     /**
      * To unite components of path in holy matrimony!
@@ -39,8 +33,6 @@ class Bundle {
     /**
      * Create a bundle from an options template
      *
-     * @constructor
-     *
      * @param {Object} options -
      * @param {Object} options.files -
      * @param {Object.<Object>} options.require -
@@ -55,10 +47,15 @@ class Bundle {
     constructor (options) {
         /**
          * @private
-         * @memberOf Bundler.prototype
          * @type {Browserify}
          */
         this.bundler = browserify({ ...bundlingOptions, ...options.bundler }); // merge with user options
+
+        /**
+         * @private
+         * @type {Boolean}
+         */
+        this.compress = options.compress;
 
         // process any list of modules externally required and also accommodate the use of built-ins if needed
         _.forEach(options.require, (options, resolve) => {
@@ -78,10 +75,6 @@ class Bundle {
             }
         });
 
-        // add the transformer for compression
-        options.compress && this.bundler.transform({ ...defaultCompressOptions.options, ...options.compress },
-            defaultCompressOptions.transformer);
-
         // ignore the items mentioned in ignore list
         _.forEach(options.ignore, this.bundler.ignore.bind(this.bundler));
 
@@ -92,7 +85,25 @@ class Bundle {
     }
 
     compile (done) {
-        return this.bundler.bundle(done);
+        this.bundler.bundle((err, bundle) => {
+            if (err) { return done(err); }
+
+            // bail out if compression is disabled
+            if (!this.compress) { return done(null, bundle.toString()); }
+
+            minify(bundle.toString(), {
+                compress: true, // enable compression
+                mangle: true, // Mangle names
+                safari10: true, // Work around the Safari 10/11 await bug (bugs.webkit.org/show_bug.cgi?id=176685)
+                format: {
+                    comments: false // Omit comments in the output
+                    // @note ascii_only is disabled since postman-sandbox v4
+                    // ascii_only: true, // Unicode characters in strings and regexps
+                }
+            }).then(({ code }) => {
+                done(null, code);
+            }).catch(done);
+        });
     }
 
     /**
@@ -108,7 +119,7 @@ class Bundle {
 
         this.bundler.on('package', addPackageToDependencies);
 
-        return this.compile((err) => {
+        this.compile((err) => {
             this.bundler.removeListener('package', addPackageToDependencies);
 
             return done(err, _.uniq(dependencies).sort());

--- a/npm/cache.js
+++ b/npm/cache.js
@@ -18,9 +18,8 @@ function createBundle (options, file, done) {
             Bundle.load(options).compile(next);
         },
 
-        function (buf, next) {
-            // eslint-disable-next-line max-len
-            fs.writeFile(file, `module.exports=function(d){d(null,Buffer.from('${buf.toString('base64')}','base64'));};`, next);
+        function (codeString, next) {
+            fs.writeFile(file, `module.exports=c=>c(null,${JSON.stringify(codeString)})`, next);
         },
 
         function (next) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -991,6 +991,18 @@
         "safe-buffer": "^5.1.1",
         "through2": "^2.0.0",
         "umd": "^3.0.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
       }
     },
     "browser-resolve": {
@@ -1117,6 +1129,16 @@
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
         }
       }
     },
@@ -1894,6 +1916,18 @@
         "shasum-object": "^1.0.0",
         "subarg": "^1.0.0",
         "through2": "^2.0.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
       }
     },
     "des.js": {
@@ -3404,6 +3438,18 @@
         "through2": "^2.0.0",
         "undeclared-identifiers": "^1.1.2",
         "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
       }
     },
     "interpret": {
@@ -5117,6 +5163,18 @@
         "subarg": "^1.0.0",
         "through2": "^2.0.0",
         "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
       }
     },
     "moment": {
@@ -6909,24 +6967,6 @@
         "urix": "^0.1.0"
       }
     },
-    "source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
     "source-map-url": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
@@ -7396,21 +7436,45 @@
       "integrity": "sha1-yTl/rVmNZiAn5NOl+n59ocg2FUc="
     },
     "terser": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-      "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.4.tgz",
+      "integrity": "sha512-dxuB8KQo8Gt6OVOeLg/rxfcxdNZI/V1G6ze1czFUzPeCFWZRtvZMgSzlZZ5OYBZ4HoG607F6pFPNLekJyV+yVw==",
       "dev": true,
       "requires": {
-        "commander": "^2.19.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.10"
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.19"
       },
       "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
         }
       }
     },
@@ -7452,16 +7516,6 @@
       "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
-    },
-    "through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
     },
     "timers-browserify": {
       "version": "1.4.2",
@@ -7635,19 +7689,6 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
-    },
-    "uglifyify": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/uglifyify/-/uglifyify-5.0.2.tgz",
-      "integrity": "sha512-NcSk6pgoC+IgwZZ2tVLVHq+VNKSvLPlLkF5oUiHPVOJI0s/OlSVYEGXG9PCAH0hcyFZLyvt4KBdPAQBRlVDn1Q==",
-      "dev": true,
-      "requires": {
-        "convert-source-map": "~1.1.0",
-        "minimatch": "^3.0.2",
-        "terser": "^3.7.5",
-        "through": "~2.3.4",
-        "xtend": "^4.0.1"
-      }
     },
     "umd": {
       "version": "3.0.3",
@@ -7864,6 +7905,18 @@
         "outpipe": "^1.1.0",
         "through2": "^2.0.0",
         "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -85,10 +85,10 @@
     "shelljs": "^0.8.4",
     "sinon": "^9.1.0",
     "sinon-chai": "^3.5.0",
+    "terser": "^5.3.4",
     "tough-cookie": "3.0.1",
     "tsd-jsdoc": "^2.5.0",
     "tv4": "1.3.0",
-    "uglifyify": "^5.0.2",
     "uniscope": "2.0.0",
     "watchify": "^3.11.1",
     "xml2js": "0.4.23"

--- a/test/system/bootcode-size.test.js
+++ b/test/system/bootcode-size.test.js
@@ -3,7 +3,7 @@ const fs = require('fs'),
     expect = require('chai').expect,
 
     CACHE_DIR = path.join(__dirname, '/../../.cache'),
-    THRESHOLD = 5.5 * 1024 * 1024; // 5.5 MB
+    THRESHOLD = 3.7 * 1024 * 1024; // 3.7 MB
 
 describe('bootcode size', function () {
     this.timeout(60 * 1000);

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -497,7 +497,6 @@ describe('sandbox library - pm api', function () {
             context.execute(`
                 var assert = require('assert');
                 assert.strictEqual(typeof pm.cookies.jar, 'function');
-                assert.strictEqual(pm.cookies.jar().constructor.name, 'PostmanCookieJar');
             `, {
                 context: { cookies: [] }
             }, done);


### PR DESCRIPTION
|                     | Before  | After   | % Change |
|---------------------|---------|---------|----------|
| bootcode.js         | 5464442 | 3643552 | 33.32%   |
| bootcode.browser.js | 5360382 | 3578586 | 33.24%   |

Also, store boot code as a UTF-8 code string instead of a Base64 buffer.