### PR TITLE
Added postinstall script to override locales exported by faker

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -6,7 +6,8 @@ master:
     - GH-605 Sanitized the global scope by deleting the forbidden properties
   chores:
     - GH-609 Bumped uvm (Web Worker bridge) and uniscope dependency
-    - GH-615 Used terser for bootcode compression and store as utf8 code string
+    - GH-615 Used terser for bootcode compression and store as UTF-8 code string
+    - GH-616 Added postinstall script to override locales exported by faker
     - GH-613 Converted internal function implementations to ES6 class
     - GH-613 Removed uuid and inherits dependencies
     - >-

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// ---------------------------------------------------------------------------------------------------------------------
+// This script is intended to execute all required checks after a package is installed.
+// ---------------------------------------------------------------------------------------------------------------------
+
+const fs = require('fs'),
+    chalk = require('chalk'),
+
+    FAKER_LOCALES = 'faker/lib/locales';
+
+console.info(chalk.yellow.bold('Overriding "faker" module content...'));
+
+try {
+    // Override locales exported by faker otherwise all the locales data will be
+    // bundled by browserify.
+    fs.writeFileSync(require.resolve(FAKER_LOCALES),
+        // only export `en` locale as required by postman-collection
+        // refer: https://github.com/postmanlabs/postman-collection/blob/v3.6.7/lib/superstring/dynamic-variables.js#L1
+        "exports['en'] = require('./locales/en');"); // eslint-disable-line quotes
+
+    const locales = Object.keys(require(FAKER_LOCALES));
+
+    if (!(locales.length === 1 && locales[0] === 'en')) {
+        throw new Error('faker locales overriding failed.');
+    }
+}
+catch (error) {
+    console.info(chalk.red.bold(error));
+    process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "test-vm": "node npm/test-vm.js",
     "pretest": "npm run cache",
     "test": "npm run test-lint && npm run test-system && npm run test-unit && npm run test-vm && npm run test-integration && npm run test-browser",
-    "prepublishOnly": "node npm/prepublish.js"
+    "prepublishOnly": "node npm/prepublish.js",
+    "postinstall": "node npm/postinstall.js"
   },
   "dependencies": {
     "lodash": "4.17.20",

--- a/test/system/bootcode-size.test.js
+++ b/test/system/bootcode-size.test.js
@@ -3,7 +3,7 @@ const fs = require('fs'),
     expect = require('chai').expect,
 
     CACHE_DIR = path.join(__dirname, '/../../.cache'),
-    THRESHOLD = 3.7 * 1024 * 1024; // 3.7 MB
+    THRESHOLD = 2.5 * 1024 * 1024; // 2.5 MB
 
 describe('bootcode size', function () {
     this.timeout(60 * 1000);

--- a/test/unit/sandbox-libraries/postman-collection.test.js
+++ b/test/unit/sandbox-libraries/postman-collection.test.js
@@ -91,4 +91,29 @@ describe('sandbox library - postman-collection', function () {
             assert.strictEqual(variables.syncVariablesTo().var2, 'val2');
         `, done);
     });
+
+    it('should resolve dynamic variables using pm.variables.replaceIn', function (done) {
+        context.execute(`
+            var assert = require('assert'),
+                replaceIn = pm.variables.replaceIn,
+                variables = [
+                    '$guid', '$timestamp', '$isoTimestamp', '$randomInt', '$randomPhoneNumber', '$randomWords',
+                    '$randomLocale', '$randomDirectoryPath', '$randomCity', '$randomCountry', '$randomBs',
+                    '$randomUrl', '$randomPassword', '$randomFullName', '$randomMonth', '$randomLoremParagraphs'
+                ],
+                guidRE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+                ipRE = /^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}(?= - -)/;
+
+            for (var variable of variables) {
+                var resolved = replaceIn(\`{{\${variable}}}\`);
+                assert.notStrictEqual(resolved, \`{{\${variable}}}\`);
+            }
+
+            assert.ok(guidRE.test(replaceIn("{{$guid}}")));
+            assert.ok(replaceIn("{{$randomWords}}").split(' ').length > 1);
+            assert.ok(replaceIn('{{$randomPhoneNumber}}').length === 12);
+            assert.ok(replaceIn('{{$randomBankAccount}}').length === 8);
+            assert.strictEqual(replaceIn('{{$randomImageUrl}}'), 'http://placeimg.com/640/480');
+        `, { debug: true }, done);
+    });
 });


### PR DESCRIPTION
After #615

|                     | Before  | After   | % Change |
|---------------------|---------|---------|----------|
| bootcode.js         | 3643552 | 2560908 | 29.71%   |
| bootcode.browser.js | 3578586 | 2496070 | 30.24%   |

Override locales exported by faker and only export `en` locale. Otherwise all the locales data will be bundled by browserify.