### PR TITLE
Support Promise execution in the sandbox.

### DIFF
--- a/lib/sandbox/execute-context.js
+++ b/lib/sandbox/execute-context.js
@@ -56,13 +56,17 @@ module.exports = function (scope, code, execution, console, timers, pmapi, onAss
         // call this hook to perform any post script execution tasks
         legacy.finish(scope, pmapi, onAssertion);
 
-        // if timers are running, we do not need to proceed with any logic of completing execution. instead we wait
-        // for timer completion callback to fire
-        if (execution.return.async) {
-            return err && timers.error(err); // but if we had error, we pass it to async error handler
+        function complete () {
+            // if timers are running, we do not need to proceed with any logic of completing execution. instead we wait
+            // for timer completion callback to fire
+            if (execution.return.async) {
+                return err && timers.error(err); // but if we had error, we pass it to async error handler
+            }
+
+            // at this stage, the script is a synchronous script, we simply forward whatever has come our way
+            timers.terminate(err);
         }
 
-        // at this stage, the script is a synchronous script, we simply forward whatever has come our way
-        timers.terminate(err);
+        timers.wrapped.setImmediate(complete);
     });
 };

--- a/lib/sandbox/execute.js
+++ b/lib/sandbox/execute.js
@@ -143,6 +143,8 @@ module.exports = function (bridge, glob) {
         let waiting,
             timers;
 
+        execution.return.async = false;
+
         // create the controlled timers
         timers = new PostmanTimers(null, function (err) {
             if (err) { // propagate the error out of sandbox
@@ -153,7 +155,7 @@ module.exports = function (bridge, glob) {
             execution.return.async = true;
         }, function (err, dnd) {
             // clear timeout tracking timer
-            waiting && (waiting = clearTimeout(waiting));
+            waiting && (waiting = timers.wrapped.clearTimeout(waiting));
 
             // do not allow any more timers
             if (timers) {
@@ -180,7 +182,7 @@ module.exports = function (bridge, glob) {
 
         // if a timeout is set, we must ensure that all pending timers are cleared and an execution timeout event is
         // triggered.
-        _.isFinite(options.timeout) && (waiting = setTimeout(function () {
+        _.isFinite(options.timeout) && (waiting = timers.wrapped.setTimeout(function () {
             timers.terminate(new Error('sandbox: ' +
                 (execution.return.async ? 'asynchronous' : 'synchronous') + ' script execution timeout'));
         }, options.timeout));

--- a/lib/sandbox/timers.js
+++ b/lib/sandbox/timers.js
@@ -114,7 +114,6 @@ function Timerz (delegations, onError, onAnyTimerStart, onAllTimerEnd) {
         total = 0, // accumulator to keep track of total timers
         pending = 0, // counters to keep track of running timers
         sealed = false, // flag that stops all new timer additions
-        wentAsync = false,
         computeTimerEvents;
 
     // do special handling to enable emulation of immediate timers in hosts that lacks them
@@ -158,11 +157,15 @@ function Timerz (delegations, onError, onAnyTimerStart, onAllTimerEnd) {
     computeTimerEvents = function (increment, clearing) {
         increment && (pending += increment);
 
-        if (pending === 0 && computeTimerEvents.started) {
-            !clearing && (typeof onAllTimerEnd === FUNCTION) && onAllTimerEnd();
-            computeTimerEvents.started = false;
+        function maybeEndAllTimers () {
+            if (pending === 0 && computeTimerEvents.started) {
+                !clearing && (typeof onAllTimerEnd === FUNCTION) && onAllTimerEnd();
+                computeTimerEvents.started = false;
+            }
+        }
 
-            return;
+        if (pending === 0 && computeTimerEvents.started) {
+            timers.setImmediate(maybeEndAllTimers);
         }
 
         if (pending > 0 && !computeTimerEvents.started) {
@@ -187,8 +190,6 @@ function Timerz (delegations, onError, onAnyTimerStart, onAllTimerEnd) {
                 args = arrayProtoSlice.call(arguments);
 
             args[0] = function () {
-                wentAsync = true; // mark that we did go async once. this will ensure we do not pass erroneous events
-
                 // call the actual callback with a dummy context
                 try { callback.apply(dummyContext, staticTimerFunctions[name] ? arguments : null); }
                 catch (e) { onError && onError(e); }
@@ -206,9 +207,6 @@ function Timerz (delegations, onError, onAnyTimerStart, onAllTimerEnd) {
                     delete running[id];
                 }
             };
-
-            // for static timers
-            staticTimerFunctions[name] && (wentAsync = true);
 
             // call the underlying timer function and keep a track of its irq
             running[id] = timers[('set' + name)].apply(this, args);
@@ -241,7 +239,7 @@ function Timerz (delegations, onError, onAnyTimerStart, onAllTimerEnd) {
             catch (e) { onError(e); }
 
             // decrement counters and call the clearing timer function
-            computeTimerEvents(-1, !wentAsync);
+            computeTimerEvents(-1);
 
             args = underLyingId = null; // just a precaution
         };
@@ -276,6 +274,8 @@ function Timerz (delegations, onError, onAnyTimerStart, onAllTimerEnd) {
     this.queueLength = function () {
         return pending;
     };
+
+    this.wrapped = timers;
 
     /**
      * @memberof Timerz.prototype

--- a/test/unit/sandbox-promises.test.js
+++ b/test/unit/sandbox-promises.test.js
@@ -1,0 +1,329 @@
+const { expect } = require('chai');
+
+describe('promises inside sandbox', function () {
+    this.timeout(1000 * 60);
+    var Sandbox = require('../../lib');
+
+    it('should set the execution to return async when a completed microtask includes a timer', function (done) {
+        Sandbox.createContext({ debug: false }, function (err, ctx) {
+            if (err) {
+                return done(err);
+            }
+
+            var executionError = sinon.spy();
+
+            ctx.on('execution.error', executionError);
+
+            ctx.execute(`
+                const message = new Promise((resolve) => {
+                    resolve("test");
+                });
+                message.then((result) => {
+                    setImmediate(() => { });
+                });
+            `,
+            function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                expect(res).to.nested.include({
+                    'return.async': true
+                });
+
+                expect(executionError).to.not.have.been.called;
+
+                done();
+            });
+        });
+    });
+
+    it('should set the execution to return non-async when a completed microtask has no timer', function (done) {
+        Sandbox.createContext({ debug: false }, function (err, ctx) {
+            if (err) {
+                return done(err);
+            }
+
+            var executionError = sinon.spy();
+
+            ctx.on('execution.error', executionError);
+
+            ctx.execute(`
+                const message = new Promise((resolve) => {
+                    resolve("test");
+                });
+                message.then((msg) => {
+                    console.log(msg);
+                });
+            `,
+            function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                expect(res).to.nested.include({
+                    'return.async': false
+                });
+
+                expect(executionError).to.not.have.been.called;
+
+                done();
+            });
+        });
+    });
+
+    it('should call assertions once resolved', function (done) {
+        Sandbox.createContext({ debug: false }, function (err, ctx) {
+            if (err) {
+                return done(err);
+            }
+
+            var executionError = sinon.spy(),
+                executionAssertion = sinon.spy();
+
+            ctx.on('execution.error', executionError);
+            ctx.on('execution.assertion', executionAssertion);
+
+            ctx.execute(`
+                pm.test('one test', function (done) {
+                    const message = new Promise((resolve) => {
+                        resolve();
+                    });
+                    message.then((result) => {
+                        return new Promise((resolve) => {
+                            setImmediate(() => resolve());
+                        })
+                    }).then(() => {
+                        done();
+                    });
+                });
+            `,
+            function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                expect(res).to.nested.include({
+                    'return.async': true
+                });
+
+                expect(executionError).to.not.have.been.called;
+
+
+                expect(executionAssertion).to.have.been.calledOnce;
+
+                expect(executionAssertion.args[0][0]).to.be.an('object').and.have.property('execution');
+                expect(executionAssertion.args[0][1]).to.be.an('array').and.have.property('length', 1);
+                expect(executionAssertion.args[0][1][0]).to.be.an('object')
+                    .and.include({
+                        passed: true,
+                        async: true
+                    });
+
+
+                done();
+            });
+        });
+    });
+
+    it('should terminate script ' +
+        'if async done is not called in a Promise', function (done) {
+        Sandbox.createContext({ debug: false }, function (err, ctx) {
+            if (err) { return done(err); }
+
+            var executionError = sinon.spy(),
+                executionAssertion = sinon.spy();
+
+            ctx.on('execution.error', executionError);
+            ctx.on('execution.assertion', executionAssertion);
+
+            ctx.execute(`
+                pm.test('one test', function (done) {
+                    Promise.resolve(42).then(function () {
+                        // done not called
+                    });
+                });
+            `, function (err, res) {
+                if (err) { return done(err); }
+
+                expect(res).to.nested.include({
+                    'return.async': false
+                });
+                expect(executionError).to.not.have.been.called;
+                expect(executionAssertion).to.not.have.been.called;
+                expect(err).to.be.null; // no error
+
+                done();
+            });
+        });
+    });
+
+    it('should forward errors from a Promise', function (done) {
+        Sandbox.createContext({ debug: false }, function (err, ctx) {
+            if (err) { return done(err); }
+
+            var executionError = sinon.spy(),
+                executionAssertion = sinon.spy();
+
+            ctx.on('execution.error', executionError);
+            ctx.on('execution.assertion', executionAssertion);
+
+            ctx.execute(`
+                pm.test('one test', function (done) {
+                    Promise.resolve('Catch me if you can').then((msg) => {
+                        setImmediate(() => {
+                            done(new Error(msg))
+                        });
+                    })
+                });
+            `, function (err) {
+                if (err) { return done(err); }
+
+                expect(executionError).to.not.have.been.called;
+                expect(executionAssertion).to.have.been.calledOnce;
+
+                expect(executionAssertion.args[0][0]).to.be.an('object').and.have.property('execution');
+                expect(executionAssertion.args[0][1]).to.be.an('array').and.have.property('length', 1);
+                expect(executionAssertion.args[0][1][0]).to.be.an('object')
+                    .and.deep.include({
+                        passed: false,
+                        async: true,
+                        error: {
+                            type: 'Error',
+                            name: 'Error',
+                            message: 'Catch me if you can'
+                        }
+                    });
+                done();
+            });
+        });
+    });
+
+    it('should forward synchronous ' +
+        'errors from asynchronous Promise tests', function (done) {
+        Sandbox.createContext({ debug: false }, function (err, ctx) {
+            if (err) { return done(err); }
+
+            var executionError = sinon.spy(),
+                executionAssertion = sinon.spy();
+
+            ctx.on('execution.error', executionError);
+            ctx.on('execution.assertion', executionAssertion);
+
+            ctx.execute(`
+                pm.test('one test', function (done) {
+                    new Promise((resolve) => {
+                        resolve('Catch me if you can');
+                    }).then((msg) => {
+                        setImmediate(() => {
+                            done(new Error(msg));
+                        });
+                    })
+
+                    throw new Error('there is no right way to do something wrong');
+                });
+            `, function (err) {
+                if (err) { return done(err); }
+
+                expect(executionError).to.not.have.been.called;
+                expect(executionAssertion).to.have.been.calledOnce;
+
+                expect(executionAssertion.args[0][0]).to.be.an('object').and.have.property('execution');
+                expect(executionAssertion.args[0][1]).to.be.an('array').and.have.property('length', 1);
+                expect(executionAssertion.args[0][1][0]).to.be.an('object')
+                    .and.deep.include({
+                        passed: false,
+                        async: true,
+                        error: {
+                            type: 'Error',
+                            name: 'Error',
+                            message: 'there is no right way to do something wrong'
+                        }
+                    });
+                done();
+            });
+        });
+    });
+
+    it('runs consecutive Promises when an async function executes in a microtask queue', function (done) {
+        Sandbox.createContext({}, function (err, ctx) {
+            if (err) { return done(err); }
+
+            var executionError = sinon.spy(),
+                onConsole = sinon.spy();
+
+            ctx.on('execution.error', executionError);
+            ctx.on('console', onConsole);
+
+            ctx.execute(`
+                const foo = () => new Promise((resolve) => {
+                    console.log('foo');
+                    setTimeout(resolve, 200);
+                });
+
+                const bar = () => new Promise((resolve) => {
+                    console.log('bar');
+                    resolve();
+                });
+
+                const baz = () => new Promise((resolve) => {
+                    console.log('baz');
+                    resolve();
+                });
+
+                Promise.resolve()
+                    .then(() => foo())
+                    .then(() => bar())
+                    .then(() => baz());
+            `, function (err) {
+                if (err) { return done(err); }
+
+                expect(executionError).to.not.have.been.called;
+                expect(onConsole).to.have.callCount(3);
+                done();
+            });
+        });
+    });
+
+    it('runs consecutive Promises when an async function executes in a microtask queue (async/await)', function (done) {
+        Sandbox.createContext({}, function (err, ctx) {
+            if (err) { return done(err); }
+
+            var executionError = sinon.spy(),
+                onConsole = sinon.spy();
+
+            ctx.on('execution.error', executionError);
+            ctx.on('console', onConsole);
+
+            ctx.execute(`
+                const foo = () => new Promise((resolve) => {
+                    console.log('foo');
+                    setTimeout(resolve, 200);
+                });
+
+                const bar = () => new Promise((resolve) => {
+                    console.log('bar');
+                    resolve();
+                });
+
+                const baz = () => new Promise((resolve) => {
+                    console.log('baz');
+                    resolve();
+                });
+
+                (async function main() {
+                  await Promise.resolve()
+                  await foo();
+                  await bar();
+                  await baz();
+                })();
+            `, function (err) {
+                if (err) { return done(err); }
+
+                expect(executionError).to.not.have.been.called;
+                expect(onConsole).to.have.callCount(3);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Promise.prototype.then arguments are executed in a microtask queue,
pushed to the end of the current event loop tick. The async
lifetime tracking in the sandbox did not factor this into
consideration. Certain completion functions needed to be deferred
with setImmediate(), which will add to the task queue and
execute after the current microtask queue drains.

Calls to global timers also needed to be wrapped in a scoped context.
Due to the setImmediate() delay, the bridge may disconnect when the
context is disposed before the completion timer fires. Disconnecting
the bridge removes all globals. This prevents reference errors from
happening on the final tick.

Original behavior of execution.return.async remains.  It will only
be set to `true` if there's a pending timer that hasn't been
previously cleared.

A code example that will show the current issue of early exit:

```js
const foo = () => new Promise((resolve) => {
  console.log('foo');
  setTimeout(resolve, 200);
});

const bar = () => new Promise((resolve) => {
  console.log('bar');
  resolve();
});

const baz = () => new Promise((resolve) => {
  console.log('baz');
  resolve();
});

Promise.resolve()
  .then(() => foo())
  .then(() => bar())
  .then(() => baz());
```

The issue occurs when async tracking happens within the microtask queue.  Without these changes, the sandbox believes all async functions are done and exits.  Using `setImmediate` in a couple of places defers that check to the beginning of the next tick, after the current tick's microtask queue is drained.