### PR TITLE
Fix memory leak due to listeners

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+unreleased:
+  fixed bugs:
+    - GH-884 Fixed memory leak due to console and cookie listeners
+
 4.2.0:
   date: 2022-11-28
   new features:

--- a/lib/postman-sandbox.js
+++ b/lib/postman-sandbox.js
@@ -110,10 +110,7 @@ class PostmanSandbox extends UniversalVM {
             }
 
             this.emit('execution', err, id, result);
-
-            // remove console event listener to avoid memory leaks
             this.removeAllListeners(consoleEventName);
-
             callback(err, result);
         });
 

--- a/lib/postman-sandbox.js
+++ b/lib/postman-sandbox.js
@@ -110,6 +110,10 @@ class PostmanSandbox extends UniversalVM {
             }
 
             this.emit('execution', err, id, result);
+
+            // remove console event listener to avoid memory leaks
+            this.removeAllListeners(consoleEventName);
+
             callback(err, result);
         });
 

--- a/lib/sandbox/execute.js
+++ b/lib/sandbox/execute.js
@@ -166,8 +166,6 @@ module.exports = function (bridge, glob) {
             // remove listener of disconnection event
             bridge.off(abortEventName);
             bridge.off(responseEventName);
-
-            // remove cookie event listener to avoid memory leaks
             bridge.off(cookiesEventName);
 
             if (err) { // fire extra execution error event

--- a/lib/sandbox/execute.js
+++ b/lib/sandbox/execute.js
@@ -167,6 +167,9 @@ module.exports = function (bridge, glob) {
             bridge.off(abortEventName);
             bridge.off(responseEventName);
 
+            // remove cookie event listener to avoid memory leaks
+            bridge.off(cookiesEventName);
+
             if (err) { // fire extra execution error event
                 bridge.dispatch(errorEventName, options.cursor, err);
                 bridge.dispatch(EXECUTION_ERROR_EVENT, options.cursor, err);


### PR DESCRIPTION
Removed execution.console.{{id}} and execution.cookies.{{id}} listeners after an execution is completed to free up heap memory.
