### PR TITLE
Fix console.log inside a function not working

### DIFF
--- a/lib/postman-sandbox.js
+++ b/lib/postman-sandbox.js
@@ -110,7 +110,6 @@ class PostmanSandbox extends UniversalVM {
             }
 
             this.emit('execution', err, id, result);
-            this.removeAllListeners(consoleEventName);
             callback(err, result);
         });
 

--- a/test/unit/sandbox-console.test.js
+++ b/test/unit/sandbox-console.test.js
@@ -331,7 +331,7 @@ describe('console inside sandbox', function () {
         });
     });
 
-    it('should allow calling console.log inside a function', function (done) {
+    it('should allow calling console.log inside a function to be reused', function (done) {
         Sandbox.createContext({}, function (err, ctx) {
             var consoleEventArgs;
 

--- a/test/unit/sandbox-console.test.js
+++ b/test/unit/sandbox-console.test.js
@@ -330,4 +330,41 @@ describe('console inside sandbox', function () {
             });
         });
     });
+
+    it('should allow calling console.log inside a function', function (done) {
+        Sandbox.createContext({}, function (err, ctx) {
+            var consoleEventArgs;
+
+            if (err) {
+                return done(err);
+            }
+
+            ctx.on('error', done);
+            ctx.on('console', function () {
+                consoleEventArgs = arguments;
+            });
+
+            ctx.execute('testLog = function () { console.log("from context 1"); };', {
+                serializeLogs: true
+            }, function (err) {
+                if (err) {
+                    return done(err);
+                }
+
+                ctx.execute('testLog();', {
+                    serializeLogs: true
+                }, function (err) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    expect(consoleEventArgs, 'console event should exist').to.exist;
+                    expect(consoleEventArgs[0]).to.be.an('object');
+                    expect(consoleEventArgs[1]).to.be.a('string').and.equal('log');
+                    expect(consoleEventArgs[2]).to.be.a('string').and.equal('[["1"],"from context 1"]');
+                    done();
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
When a `console.log` is inside a function and that function is called from any other script except this one, then the log is not sent. This change reverts a change in 446f9d2 which causes this issue.

Ref: https://github.com/postmanlabs/postman-app-support/issues/11710