### PR TITLE
Support async functions as callback in pm.test

### DIFF
--- a/lib/sandbox/pmapi-setup-runner.js
+++ b/lib/sandbox/pmapi-setup-runner.js
@@ -104,12 +104,16 @@ module.exports = function (pm, onAssertionComplete) {
         }
         // if the assertion function does not expect a callback, we synchronously execute the same
         else {
-            try { assert(); }
+            try { 
+                Promise.resolve(assert())
+                    .catch(e => markAssertionAsFailure(assertionData, e))
+                    .finally(() => onAssertionComplete(assertionData));
+            }
             catch (e) {
                 markAssertionAsFailure(assertionData, e);
+                onAssertionComplete(assertionData);
             }
 
-            onAssertionComplete(assertionData);
         }
 
         return pm; // make it chainable


### PR DESCRIPTION
Async functions return a promise. Currently with pm.test('description', async function () {}) will mark the test as successfull and completed, even if an exception is thrown.