### PR TITLE
feat(skip-execution): add support to display system logs

### DIFF
--- a/lib/sandbox/console.js
+++ b/lib/sandbox/console.js
@@ -10,6 +10,8 @@ var teleportJS = require('teleport-javascript'),
      */
     CONSOLE_EVENT = 'execution.console',
 
+    SYSTEM_MESSAGE = 'system_message',
+
     /**
      * List of functions that we expect and create for console
      *
@@ -66,4 +68,17 @@ function PostmanConsole (emitter, cursor, originalConsole, execution) {
     });
 }
 
-module.exports = PostmanConsole;
+/**
+ *
+ * @param {{log: Function}} console - postman console instance
+ * @param {'skip_request'} type - this is used to identify the message type in postman-app
+ * @param  {...any} args - any other information like request name to be used to generate console message
+ */
+function dispatchSystemMessage (console, type, ...args) {
+    return console.log(SYSTEM_MESSAGE, type, ...args);
+}
+
+module.exports = {
+    default: PostmanConsole,
+    dispatchSystemMessage: dispatchSystemMessage
+};

--- a/lib/sandbox/execute.js
+++ b/lib/sandbox/execute.js
@@ -5,7 +5,7 @@ const _ = require('lodash'),
     sdk = require('postman-collection'),
     PostmanEvent = sdk.Event,
     Execution = require('./execution'),
-    PostmanConsole = require('./console'),
+    { default: PostmanConsole, dispatchSystemMessage } = require('./console'),
     PostmanTimers = require('./timers'),
     PostmanAPI = require('./pmapi'),
     PostmanCookieStore = require('./cookie-store'),
@@ -143,7 +143,8 @@ module.exports = function (bridge, glob) {
             };
 
         let waiting,
-            timers;
+            timers,
+            postmanConsole;
 
         execution.return.async = false;
 
@@ -211,11 +212,13 @@ module.exports = function (bridge, glob) {
             timers.clearEvent(id, err, res);
         });
 
+        postmanConsole = new PostmanConsole(bridge, options.cursor, options.debug && glob.console, execution);
+
         // send control to the function that executes the context and prepares the scope
         executeContext(scope, code, execution,
             // if a console is sent, we use it. otherwise this also prevents erroneous referencing to any console
             // inside this closure.
-            (new PostmanConsole(bridge, options.cursor, options.debug && glob.console, execution)),
+            postmanConsole,
             timers,
             (
                 new PostmanAPI(execution, function (request, callback) {
@@ -223,6 +226,9 @@ module.exports = function (bridge, glob) {
 
                     dispatchEvent(bridge, execution, executionRequestEventName, options.cursor, id, eventId, request);
                 }, /* onStopExecution = */ function () {
+                    // Dispatch event to display system message on console informing user that the request
+                    // execution was skipped from script
+                    dispatchSystemMessage(postmanConsole, 'skip_request', _.get(execution, 'legacy._itemName'));
                     execution.shouldSkipExecution = true;
                     timers.terminate(null);
                 },

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -279,9 +279,9 @@ describe('sandbox library - pm api', function () {
         });
 
         it('should not execute any line after pm.request.stopExecution in pre-request script', function (done) {
-            context.on('console', function (level, ...args) {
-                expect(args[1]).to.equal('pre-request log 1');
-            });
+            const consoleSpy = sinon.spy();
+
+            context.on('console', consoleSpy);
             context.execute(`
                 preRequestScript: {
                     console.log('pre-request log 1');
@@ -292,20 +292,38 @@ describe('sandbox library - pm api', function () {
                 timeout: 200,
                 context: {
                     request: 'https://postman-echo.com/get?foo=bar'
+                },
+                legacy: {
+                    _itemName: 'request-name',
+                    _itemId: 'request-id',
+                    _itemPath: 'col1/fol1/request-name'
                 }
             }, function (err, execution) {
                 if (err) { return done(err); }
-                expect(execution).to.include({ shouldSkipExecution: true });
 
-                return done();
+                try {
+                    expect(execution).to.include({ shouldSkipExecution: true });
+                    expect(consoleSpy).to.have.been.calledTwice;
+                    expect(consoleSpy.getCall(0).args[1]).to.equal('log');
+                    expect(consoleSpy.getCall(0).args[2]).to.equal('pre-request log 1');
+                    expect(consoleSpy.getCall(1).args[1]).to.equal('log');
+                    expect(consoleSpy.getCall(1).args[2]).to.equal('system_message');
+                    expect(consoleSpy.getCall(1).args[3]).to.equal('skip_request');
+                    expect(consoleSpy.getCall(1).args[4]).to.equal('request-name');
+
+                    return done();
+                }
+                catch (err) {
+                    return done(err);
+                }
             });
         });
 
         it(`should not execute any line after pm.request.stopExecution in pre-request script,
         even if the pm.request.stopExecution invoked inside a try catch block`, function (done) {
-            context.on('console', function (level, ...args) {
-                expect(args[1]).to.equal('pre-request log 1');
-            });
+            const consoleSpy = sinon.spy();
+
+            context.on('console', consoleSpy);
             context.execute(`
                 preRequestScript: {
                     console.log('pre-request log 1');
@@ -323,17 +341,30 @@ describe('sandbox library - pm api', function () {
                 }
             }, function (err, execution) {
                 if (err) { return done(err); }
-                expect(execution).to.include({ shouldSkipExecution: true });
 
-                return done();
+                try {
+                    expect(execution).to.include({ shouldSkipExecution: true });
+                    expect(consoleSpy).to.have.been.calledTwice;
+                    expect(consoleSpy.getCall(0).args[1]).to.equal('log');
+                    expect(consoleSpy.getCall(0).args[2]).to.equal('pre-request log 1');
+                    expect(consoleSpy.getCall(1).args[1]).to.equal('log');
+                    expect(consoleSpy.getCall(1).args[2]).to.equal('system_message');
+                    expect(consoleSpy.getCall(1).args[3]).to.equal('skip_request');
+                    expect(consoleSpy.getCall(1).args[4]).to.equal(undefined);
+
+                    return done();
+                }
+                catch (err) {
+                    return done(err);
+                }
             });
         });
 
         it(`should not execute any line after pm.request.stopExecution in pre-request script,
         even if the pm.request.stopExecution invoked inside an async function`, function (done) {
-            context.on('console', function (level, ...args) {
-                expect(args[1]).to.equal('pre-request log 1');
-            });
+            const consoleSpy = sinon.spy();
+
+            context.on('console', consoleSpy);
             context.execute(`
                 preRequestScript: {
                     console.log('pre-request log 1');
@@ -351,17 +382,30 @@ describe('sandbox library - pm api', function () {
                 }
             }, function (err, execution) {
                 if (err) { return done(err); }
-                expect(execution).to.include({ shouldSkipExecution: true });
 
-                return done();
+                try {
+                    expect(execution).to.include({ shouldSkipExecution: true });
+                    expect(consoleSpy).to.have.been.calledTwice;
+                    expect(consoleSpy.getCall(0).args[1]).to.equal('log');
+                    expect(consoleSpy.getCall(0).args[2]).to.equal('pre-request log 1');
+                    expect(consoleSpy.getCall(1).args[1]).to.equal('log');
+                    expect(consoleSpy.getCall(1).args[2]).to.equal('system_message');
+                    expect(consoleSpy.getCall(1).args[3]).to.equal('skip_request');
+                    expect(consoleSpy.getCall(1).args[4]).to.equal(undefined);
+
+                    return done();
+                }
+                catch (err) {
+                    return done(err);
+                }
             });
         });
 
         it('should not reflect any variable change line after pm.request.stopExecution in pre-request script',
             function (done) {
-                context.on('console', function (level, ...args) {
-                    expect(args[1]).to.equal('pre-request log 1');
-                });
+                const consoleSpy = sinon.spy();
+
+                context.on('console', consoleSpy);
                 context.execute(`
                     preRequestScript: {
                         async function myFun () {
@@ -384,12 +428,25 @@ describe('sandbox library - pm api', function () {
                     }
                 }, function (err, execution) {
                     if (err) { return done(err); }
-                    expect(execution).to.include({ shouldSkipExecution: true });
-                    expect(execution).to.deep.nested.include({ '_variables.values': [
-                        { value: 'bar', key: 'foo', type: 'any' }
-                    ] });
 
-                    return done();
+                    try {
+                        expect(execution).to.include({ shouldSkipExecution: true });
+                        expect(execution).to.deep.nested.include({ '_variables.values': [
+                            { value: 'bar', key: 'foo', type: 'any' }
+                        ] });
+                        expect(consoleSpy).to.have.been.calledTwice;
+                        expect(consoleSpy.getCall(0).args[1]).to.equal('log');
+                        expect(consoleSpy.getCall(0).args[2]).to.equal('pre-request log 1');
+                        expect(consoleSpy.getCall(1).args[1]).to.equal('log');
+                        expect(consoleSpy.getCall(1).args[2]).to.equal('system_message');
+                        expect(consoleSpy.getCall(1).args[3]).to.equal('skip_request');
+                        expect(consoleSpy.getCall(1).args[4]).to.equal(undefined);
+
+                        return done();
+                    }
+                    catch (err) {
+                        return done(err);
+                    }
                 });
             });
 


### PR DESCRIPTION
System logs will be displayed on postman app console with special highlight, they should be used when you want to inform user that some action was taken from script.