### PR TITLE
Disable legacy API in pm.require-d packages

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,4 +1,6 @@
 unreleased:
+  fixed bugs:
+    - GH-981 Dropped support for legacy sandbox APIs in packages
   new features:
     - |
       GH-984 Added `pm.execution.setNextRequest` API, similar to legacy

--- a/lib/sandbox/pm-require.js
+++ b/lib/sandbox/pm-require.js
@@ -1,4 +1,6 @@
-const MODULE_KEY = '__module_obj', // why not use `module`?
+const { LEGACY_GLOBS } = require('./postman-legacy-interface'),
+
+    MODULE_KEY = '__module_obj', // why not use `module`?
     MODULE_WRAPPER = [
         '(function (exports, module) {\n',
         `\n})(${MODULE_KEY}.exports, ${MODULE_KEY});`
@@ -158,7 +160,7 @@ function createPostmanRequire (fileCache, scope) {
         //
         // Why `async` = true?
         //   - We want to allow execution of async code like setTimeout etc.
-        scope.exec(wrappedModule, true, (err) => {
+        scope.exec(wrappedModule, { async: true, block: LEGACY_GLOBS }, (err) => {
             // Bubble up the error to be caught as execution error
             if (err) {
                 throw err;

--- a/lib/sandbox/postman-legacy-interface.js
+++ b/lib/sandbox/postman-legacy-interface.js
@@ -17,7 +17,8 @@ const _ = require('lodash'),
         'tests', 'globals', 'environment', 'data', 'request', 'responseCookies', 'responseHeaders', 'responseTime',
         'responseCode', 'responseBody', 'iteration', 'postman',
         // scope libraries
-        'JSON', '_', 'CryptoJS', 'atob', 'btoa', 'tv4', 'xml2Json', 'Backbone', 'cheerio'
+        '_', 'CryptoJS', 'atob', 'btoa', 'tv4', 'xml2Json', 'Backbone', 'cheerio'
+        // 'JSON', // removing JSON from the list since it is a standard JS object
     ],
 
     E = '',
@@ -416,5 +417,7 @@ module.exports = {
         }
 
         raiseAssertionEvent(scope, pmapi, onAssertion);
-    }
+    },
+
+    LEGACY_GLOBS
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6366,9 +6366,9 @@
       "dev": true
     },
     "uniscope": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uniscope/-/uniscope-2.1.0.tgz",
-      "integrity": "sha512-nFkkwVnj/sLUgLxffkJXTHEOCY7uuVHItzmEyEibL9OdtTrXRhd8uHBAS6kgTUrmDPpKZlz/Ts/CdEgqj6o+Tg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/uniscope/-/uniscope-2.2.0.tgz",
+      "integrity": "sha512-9afpYDKpjC0WFd0rPlSnjGUbqP5mP6U1ZqU6NrrF6ga8uCoJH2eysB5b1nAPIyFQ4jeCadQQOsKqtIMk5/VueQ==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "terser": "^5.29.1",
     "tsd-jsdoc": "^2.5.0",
     "tv4": "1.3.0",
-    "uniscope": "2.1.0",
+    "uniscope": "2.2.0",
     "watchify": "^4.0.0",
     "xml2js": "0.4.23"
   },


### PR DESCRIPTION
Disables legacy APIs from being used in packages.
The exception is JSON being provided from `liquid-json`, but we can use it anyway since the API is similar to the native JS object.