### PR TITLE
Added `pm.execution.setNextRequest`

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+unreleased:
+  new features:
+    - |
+      GH-984 Added `pm.execution.setNextRequest` API, similar to legacy
+      `postman.setNextRequest`
+
 4.5.1:
   date: 2024-03-12
   chores:

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -291,7 +291,18 @@ function Postman (execution, onRequest, onSkipRequest, onAssertion, cookieStore,
                  * @type {string}
                  */
                 current: execution.legacy._eventItemName
-            })
+            }),
+
+            /**
+             * Sets the next request to be run after the current request, when
+             * running the collection. Passing `null` stops the collection run
+             * after the current request is executed.
+             *
+             * @param {string|null} request - name of the request to run next
+             */
+            setNextRequest: function setNextRequest (request) {
+                execution.return && (execution.return.nextRequest = request);
+            }
         },
 
         /**

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -1121,5 +1121,20 @@ describe('sandbox library - pm api', function () {
                 });
             });
         });
+
+        describe('.setNextRequest', function () {
+            it('should have the next request in result.nextRequest', function (done) {
+                context.execute({
+                    listen: 'test',
+                    script: `
+                        pm.execution.setNextRequest('R2');
+                    `
+                }, {}, function (err, result) {
+                    expect(err).to.be.null;
+                    expect(result).to.have.nested.property('return.nextRequest', 'R2');
+                    done();
+                });
+            });
+        });
     });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for postman-sandbox 4.4.0
+// Type definitions for postman-sandbox 4.5.0
 // Project: https://github.com/postmanlabs/postman-sandbox
 // Definitions by: PostmanLabs
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -252,6 +252,16 @@ declare interface Visualizer {
      * Clear all visualizer data
      */
     clear(): void;
+}
+
+declare namespace Execution {
+    /**
+     * Sets the next request to be run after the current request, when
+     * running the collection. Passing `null` stops the collection run
+     * after the current request is executed.
+     * @param request - name of the request to run next
+     */
+    function setNextRequest(request: string | null): void;
 }
 
 declare interface Execution {

--- a/types/sandbox/prerequest.d.ts
+++ b/types/sandbox/prerequest.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for postman-sandbox 4.4.0
+// Type definitions for postman-sandbox 4.5.0
 // Project: https://github.com/postmanlabs/postman-sandbox
 // Definitions by: PostmanLabs
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -111,6 +111,16 @@ declare interface Visualizer {
      * Clear all visualizer data
      */
     clear(): void;
+}
+
+declare namespace Execution {
+    /**
+     * Sets the next request to be run after the current request, when
+     * running the collection. Passing `null` stops the collection run
+     * after the current request is executed.
+     * @param request - name of the request to run next
+     */
+    function setNextRequest(request: string | null): void;
 }
 
 declare interface Execution {

--- a/types/sandbox/test.d.ts
+++ b/types/sandbox/test.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for postman-sandbox 4.4.0
+// Type definitions for postman-sandbox 4.5.0
 // Project: https://github.com/postmanlabs/postman-sandbox
 // Definitions by: PostmanLabs
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -117,6 +117,16 @@ declare interface Visualizer {
      * Clear all visualizer data
      */
     clear(): void;
+}
+
+declare namespace Execution {
+    /**
+     * Sets the next request to be run after the current request, when
+     * running the collection. Passing `null` stops the collection run
+     * after the current request is executed.
+     * @param request - name of the request to run next
+     */
+    function setNextRequest(request: string | null): void;
 }
 
 declare interface Execution {


### PR DESCRIPTION
`postman.setNextRequest` exists, but it is in legacy `postman.*` interface. We're adding this in `pm.*` interface to ensure `pm.*` is a superset of the legacy interface.

The command works exactly the same.