### PR TITLE
Added support for `pm.vault` VariableScope

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,4 +1,6 @@
 unreleased:
+  new features:
+    - GH-1003 Added support for `pm.vault` VariableScope
   fixed bugs:
     - GH-1018 Fixed warnings for all `postman.*` legacy APIs
   chores:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following section outlines the API available inside sandbox scripts
 - pm.environment
 - pm.collectionVariables
 - pm.test
-- pm.vaultSecrets
+- pm.vault
 
 #### pre-request script specials
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The following section outlines the API available inside sandbox scripts
 - pm.environment
 - pm.collectionVariables
 - pm.test
+- pm.vaultSecrets
 
 #### pre-request script specials
 

--- a/README.md
+++ b/README.md
@@ -31,11 +31,18 @@ The following section outlines the API available inside sandbox scripts
 
 ### pm
 
-- pm.globals
-- pm.environment
-- pm.collectionVariables
 - pm.test
+- pm.info
 - pm.vault
+- pm.globals
+- pm.cookies
+- pm.execution
+- pm.variables
+- pm.visualizer
+- pm.sendRequest
+- pm.environment
+- pm.iterationData
+- pm.collectionVariables
 
 #### pre-request script specials
 

--- a/lib/sandbox/execution.js
+++ b/lib/sandbox/execution.js
@@ -18,7 +18,7 @@ const _ = require('lodash'),
         test: true
     },
 
-    CONTEXT_VARIABLE_SCOPES = ['_variables', 'environment', 'collectionVariables', 'globals'],
+    CONTEXT_VARIABLE_SCOPES = ['_variables', 'environment', 'collectionVariables', 'globals', 'vaultSecrets'],
 
     trackingOptions = { autoCompact: true };
 

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -63,6 +63,7 @@ function Postman (execution, onRequest, onSkipRequest, onAssertion, cookieStore,
     execution._variables.addLayer(execution.environment.values);
     execution._variables.addLayer(execution.collectionVariables.values);
     execution._variables.addLayer(execution.globals.values);
+    execution._variables.addLayer(execution.vaultSecrets.values);
 
     execution.cookies && (execution.cookies.jar = function () {
         return new PostmanCookieJar(cookieStore);
@@ -123,6 +124,11 @@ function Postman (execution, onRequest, onSkipRequest, onAssertion, cookieStore,
              */
             requestId: execution.legacy._itemId
         }),
+
+        /**
+         * @type {VariableScope}
+         */
+        vault: execution.vaultSecrets,
 
         /**
          * @type {VariableScope}

--- a/test/unit/pm-variables-tracking.test.js
+++ b/test/unit/pm-variables-tracking.test.js
@@ -26,6 +26,10 @@ describe('pm api variables', function () {
                 assert.equal(pm.collectionVariables.mutations.count(), 0);
                 pm.collectionVariables.set('foo', 'foo');
                 assert.equal(pm.collectionVariables.mutations.count(), 1);
+
+                assert.equal(pm.vault.mutations.count(), 0);
+                pm.vault.set('foo', 'foo');
+                assert.equal(pm.vault.mutations.count(), 1);
             `, done);
         });
     });
@@ -41,6 +45,7 @@ describe('pm api variables', function () {
                 pm.environment.set('foo', 'environment');
                 pm.globals.set('foo', 'global');
                 pm.collectionVariables.set('foo', 'collectionVariables');
+                pm.vault.set('foo', 'vaultVariable');
             `, function (err, result) {
                 if (err) {
                     return done(err);
@@ -57,6 +62,9 @@ describe('pm api variables', function () {
 
                 expect(result.collectionVariables.mutations).to.be.ok;
                 expect(new sdk.MutationTracker(result.collectionVariables.mutations).count()).to.equal(1);
+
+                expect(result.vaultSecrets.mutations).to.be.ok;
+                expect(new sdk.MutationTracker(result.vaultSecrets.mutations).count()).to.equal(1);
 
                 done();
             });

--- a/test/unit/pm-variables-tracking.test.js
+++ b/test/unit/pm-variables-tracking.test.js
@@ -90,16 +90,38 @@ describe('pm api variables', function () {
             ctx.execute(`
                 var assert = require('assert');
 
+                assert.equal(pm.variables.get('bar'), 'bar value');
                 pm.variables.set('foo', '_variable');
+
+                assert.equal(pm.environment.get('bar'), 'bar value');
                 pm.environment.set('foo', 'environment');
+
+                assert.equal(pm.globals.get('bar'), 'bar value');
                 pm.globals.set('foo', 'global');
+
+                assert.equal(pm.collectionVariables.get('bar'), 'bar value');
                 pm.collectionVariables.set('foo', 'collectionVariables');
+
+                assert.equal(pm.vault.get('bar'), 'bar value');
+                pm.vault.set('foo', 'vault');
             `, {
                 context: {
                     globals: scopeDefinition,
                     _variables: scopeDefinition,
                     environment: scopeDefinition,
-                    collectionVariables: scopeDefinition
+                    collectionVariables: scopeDefinition,
+                    vaultSecrets: {
+                        prefix: 'vault:',
+                        values: [
+                            { key: 'vault:bar', value: 'bar value' }
+                        ],
+                        mutations: {
+                            autoCompact: true,
+                            compacted: {
+                                'vault:bar': ['vault:bar', 'bar value']
+                            }
+                        }
+                    }
                 }
             }, function (err, result) {
                 if (err) {
@@ -117,6 +139,9 @@ describe('pm api variables', function () {
 
                 expect(result.collectionVariables.mutations).to.be.ok;
                 expect(new sdk.MutationTracker(result.collectionVariables.mutations).count()).to.equal(1);
+
+                expect(result.vaultSecrets.mutations).to.be.ok;
+                expect(new sdk.MutationTracker(result.vaultSecrets.mutations).count()).to.equal(1);
 
                 done();
             });

--- a/test/unit/pm-variables.test.js
+++ b/test/unit/pm-variables.test.js
@@ -76,10 +76,10 @@ describe('pm.variables', function () {
             ] });
         });
 
-        it('should not modify the globals, envrironment, collection and data variables', function () {
+        it('should not modify the globals, environment, collection and data variables', function () {
             expect(executionResults).to.deep.nested.include({
                 'vaultSecrets.values': [
-                    { type: 'any', key: 'vault:key-0', value: 'value-0' }
+                    { type: 'any', value: 'value-0', key: 'vault:key-0' }
                 ],
                 'globals.values': [
                     { type: 'any', value: 'value-1', key: 'key-1' }

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -1,4 +1,5 @@
-const CookieStore = require('@postman/tough-cookie').Store;
+const { VariableScope } = require('postman-collection'),
+    CookieStore = require('@postman/tough-cookie').Store;
 
 describe('sandbox library - pm api', function () {
     this.timeout(1000 * 60);
@@ -30,6 +31,17 @@ describe('sandbox library - pm api', function () {
                 value: 2.9,
                 type: 'number'
             }],
+            vaultSecrets: new VariableScope({
+                prefix: 'vault:',
+                values: [{
+                    key: 'vault:var1',
+                    value: 'one-vault',
+                    type: 'string'
+                }, {
+                    key: 'vault:var2',
+                    value: 'two-vault',
+                    type: 'string'
+                }] }),
             data: {
                 var1: 'one-data'
             }
@@ -262,6 +274,77 @@ describe('sandbox library - pm api', function () {
                     var2: 2.9
                 });
             `, { context: sampleContextData }, done);
+        });
+    });
+
+    describe('vaultSecrets', function () {
+        it('should be defined as VariableScope', function (done) {
+            context.execute(`
+                var assert = require('assert'),
+                    VariableScope = require('postman-collection').VariableScope;
+                assert.strictEqual(VariableScope.isVariableScope(pm.vault), true);
+            `, { context: sampleContextData }, done);
+        });
+
+        it('should be a readonly property', function (done) {
+            context.execute(`
+                var assert = require('assert'),
+                    _vaultSecrets;
+
+                _vaultSecrets = pm.vault;
+                pm.vault = [];
+
+                assert.strictEqual(pm.vault, _vaultSecrets, 'property stays unchanged');
+            `, { context: sampleContextData }, done);
+        });
+
+        it('should forward vaultSecrets forwarded during execution', function (done) {
+            context.execute(`
+                var assert = require('assert');
+                assert.strictEqual(pm.vault.get('var1'), 'one-vault');
+                assert.strictEqual(pm.vault.get('var2'), 'two-vault');
+            `, { context: sampleContextData }, done);
+        });
+
+        it('pm.vault.toObject must return a pojo', function (done) {
+            context.execute(`
+                var assert = require('assert');
+
+                assert.strictEqual(_.isPlainObject(pm.vault.toObject()), true);
+                assert.deepEqual(pm.vault.toObject(), {
+                    'vault:var1': 'one-vault',
+                    'vault:var2': 'two-vault'
+                });
+            `, { context: sampleContextData }, done);
+        });
+        it('pm.variables.toObject must contain vaultSecrets', function (done) {
+            context.execute(`
+                var assert = require('assert');
+
+                assert.strictEqual(_.isPlainObject(pm.variables.toObject()), true);
+                assert.deepEqual(pm.variables.toObject(), {
+                    'vault:var1': 'one-vault',
+                    'vault:var2': 'two-vault',
+                    'var1': 'one-data',
+                    'var2': 2.5
+                });
+            `, { context: sampleContextData }, done);
+        });
+        it('should propagate updated vault secrets from inside sandbox', function (done) {
+            context.execute(`
+                var assert = require('assert');
+
+                pm.vault.set('var1', 'one-one-vault');
+                assert.strictEqual(pm.vault.get('var1'), 'one-one-vault');
+            `, { context: sampleContextData }, function (err, exec) {
+                expect(err).to.be.null;
+                expect(exec).to.be.ok;
+                expect(exec).to.deep.nested.include({ 'vaultSecrets.values': [
+                    { type: 'string', value: 'one-one-vault', key: 'vault:var1' },
+                    { type: 'string', value: 'two-vault', key: 'vault:var2' }
+                ] });
+                done();
+            });
         });
     });
 

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -277,7 +277,7 @@ describe('sandbox library - pm api', function () {
         });
     });
 
-    describe('vaultSecrets', function () {
+    describe('vault', function () {
         it('should be defined as VariableScope', function (done) {
             context.execute(`
                 var assert = require('assert'),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -178,6 +178,7 @@ declare class Postman {
     globals: VariableScope;
     environment: VariableScope;
     collectionVariables: VariableScope;
+    vault: VariableScope;
     variables: VariableScope;
     /**
      * The iterationData object contains data from the data file provided during a collection run.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for postman-sandbox 4.7.1
+// Type definitions for postman-sandbox 5.0.0
 // Project: https://github.com/postmanlabs/postman-sandbox
 // Definitions by: PostmanLabs
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -175,10 +175,10 @@ declare class Postman {
      * stored inside of this object.
      */
     info: Info;
+    vault: VariableScope;
     globals: VariableScope;
     environment: VariableScope;
     collectionVariables: VariableScope;
-    vault: VariableScope;
     variables: VariableScope;
     /**
      * The iterationData object contains data from the data file provided during a collection run.

--- a/types/sandbox/prerequest.d.ts
+++ b/types/sandbox/prerequest.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for postman-sandbox 4.7.1
+// Type definitions for postman-sandbox 5.0.0
 // Project: https://github.com/postmanlabs/postman-sandbox
 // Definitions by: PostmanLabs
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -109,10 +109,10 @@ declare class Postman {
      * stored inside of this object.
      */
     info: Info;
+    vault: import("postman-collection").VariableScope;
     globals: import("postman-collection").VariableScope;
     environment: import("postman-collection").VariableScope;
     collectionVariables: import("postman-collection").VariableScope;
-    vault: import("postman-collection").VariableScope;
     variables: import("postman-collection").VariableScope;
     /**
      * The iterationData object contains data from the data file provided during a collection run.

--- a/types/sandbox/prerequest.d.ts
+++ b/types/sandbox/prerequest.d.ts
@@ -112,6 +112,7 @@ declare class Postman {
     globals: import("postman-collection").VariableScope;
     environment: import("postman-collection").VariableScope;
     collectionVariables: import("postman-collection").VariableScope;
+    vault: import("postman-collection").VariableScope;
     variables: import("postman-collection").VariableScope;
     /**
      * The iterationData object contains data from the data file provided during a collection run.

--- a/types/sandbox/test.d.ts
+++ b/types/sandbox/test.d.ts
@@ -142,6 +142,7 @@ declare class Postman {
     globals: import("postman-collection").VariableScope;
     environment: import("postman-collection").VariableScope;
     collectionVariables: import("postman-collection").VariableScope;
+    vault: import("postman-collection").VariableScope;
     variables: import("postman-collection").VariableScope;
     /**
      * The iterationData object contains data from the data file provided during a collection run.

--- a/types/sandbox/test.d.ts
+++ b/types/sandbox/test.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for postman-sandbox 4.7.1
+// Type definitions for postman-sandbox 5.0.0
 // Project: https://github.com/postmanlabs/postman-sandbox
 // Definitions by: PostmanLabs
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -139,10 +139,10 @@ declare class Postman {
      * stored inside of this object.
      */
     info: Info;
+    vault: import("postman-collection").VariableScope;
     globals: import("postman-collection").VariableScope;
     environment: import("postman-collection").VariableScope;
     collectionVariables: import("postman-collection").VariableScope;
-    vault: import("postman-collection").VariableScope;
     variables: import("postman-collection").VariableScope;
     /**
      * The iterationData object contains data from the data file provided during a collection run.


### PR DESCRIPTION
Main Ticket: Ability to support Vault Supports in Scripts [ https://postmanlabs.atlassian.net/browse/TRUST-1152 ]
Ticket: Add support for `pm.vault` in scripts [ https://postmanlabs.atlassian.net/browse/TRUST-1207 ]

## Why do we need this change?
- We want the user to be able to use the `pm.vault` to work with Vault Secrets.
- `get`, `set`, `replace`, `clear`, `unset`, `toObject`, `toJSON` etc all normal VariableScope operations are to be supported

## How does it work?
- Add the vaultSecrets to the execution context
- Expose `vault` through pmapi
- Update type files ( *.d.ts ) to export vault as `VariableScope` type

## What changes are remaining
- [x] Update version of `postman-collection` [ Blocked on https://github.com/postmanlabs/postman-collection/pull/1364 ]