### PR TITLE
Fix warnings for all postman.* legacy APIs

### DIFF
--- a/lib/sandbox/postman-legacy-interface.js
+++ b/lib/sandbox/postman-legacy-interface.js
@@ -41,7 +41,17 @@ const _ = require('lodash'),
         xml2Json: 'require(\'xml2js\')',
         Backbone: 'require(\'backbone\')',
         cheerio: 'require(\'cheerio\')',
-        'postman.setNextRequest': 'pm.execution.setNextRequest()'
+        'postman.setNextRequest': 'pm.execution.setNextRequest()',
+        'postman.setEnvironmentVariable': 'pm.environment.set()',
+        'postman.getEnvironmentVariable': 'pm.environment.get()',
+        'postman.clearEnvironmentVariables': 'pm.environment.clear()',
+        'postman.clearEnvironmentVariable': 'pm.environment.unset()',
+        'postman.setGlobalVariable': 'pm.globals.set()',
+        'postman.getGlobalVariable': 'pm.globals.get()',
+        'postman.clearGlobalVariables': 'pm.globals.clear()',
+        'postman.clearGlobalVariable': 'pm.globals.unset()',
+        'postman.getResponseCookie': 'pm.cookies.get()',
+        'postman.getResponseHeader': 'pm.response.headers.get()'
     },
 
     E = '',
@@ -413,16 +423,25 @@ module.exports = {
         globalvars.iteration = _.isObject(execution.cursor) ? execution.cursor.iteration : 0;
 
         // 6. create the postman interface object
+        const postmanLegacy = new (execution.target === TARGET_TEST ?
+                PostmanLegacyTestInterface : PostmanLegacyInterface)(execution, globalvars),
+
+            legacyAPIUsage = new Set();
+
+        scope.__is_deprecation_warning_enabled = true;
+
         /**
          * @memberOf SandboxGlobals
          * @type {PostmanLegacyInterface}
          */
-        globalvars.postman = new (execution.target === TARGET_TEST ?
-            PostmanLegacyTestInterface : PostmanLegacyInterface)(execution, globalvars);
+        globalvars.postman = new Proxy(postmanLegacy, {
+            get (target, prop) {
+                scope.__is_deprecation_warning_enabled &&
+                    logDeprecationWarning(`postman.${prop}`, legacyAPIUsage, console);
 
-        const legacyAPIUsage = new Set();
-
-        scope.__is_deprecation_warning_enabled = true;
+                return target[prop];
+            }
+        });
 
         // wrap all globals to ensure we track their usage to show warnings
         // on access.
@@ -439,13 +458,9 @@ module.exports = {
                 },
 
                 get (target, prop) {
-                    // special handling for postman because setNextRequest is
-                    // used a lot.
-                    if (key === 'postman') {
-                        scope.__is_deprecation_warning_enabled &&
-                            logDeprecationWarning('postman.setNextRequest', legacyAPIUsage, console);
-                    }
-                    else {
+                    // special handling for postman.* because we're handling
+                    // those in the `PostmanLegacyInterface` itself.
+                    if (key !== 'postman') {
                         scope.__is_deprecation_warning_enabled && logDeprecationWarning(key, legacyAPIUsage, console);
                     }
 

--- a/test/unit/sandbox-libraries/legacy.test.js
+++ b/test/unit/sandbox-libraries/legacy.test.js
@@ -94,21 +94,25 @@ describe('sandbox library - legacy', function () {
         });
     });
 
-    it('should have special handling for postman.setNextRequest', function (done) {
+    it('should have special handling for postman.*', function (done) {
         const consoleSpy = sinon.spy();
 
         context.on('console', consoleSpy);
         context.execute(`
             postman.setNextRequest('abc');
+            postman.setEnvironmentVariable('foo', 'bar');
         `, function (err) {
             if (err) {
                 return done(err);
             }
 
-            expect(consoleSpy).to.be.calledOnce;
+            expect(consoleSpy).to.be.calledTwice;
             expect(consoleSpy.firstCall.args[1]).to.equal('warn');
             expect(consoleSpy.firstCall.args[2])
                 .to.equal('Using "postman.setNextRequest" is deprecated. Use "pm.execution.setNextRequest()" instead.');
+            expect(consoleSpy.secondCall.args[1]).to.equal('warn');
+            expect(consoleSpy.secondCall.args[2])
+                .to.equal('Using "postman.setEnvironmentVariable" is deprecated. Use "pm.environment.set()" instead.');
             done();
         });
     });


### PR DESCRIPTION
We were missing some deprecation warnings for `postman.*` APIs. This change adds all the warnings for those APIs.