### PR TITLE
Truncate large response body in legacy sandbox

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,6 @@
+unreleased:
+  fixed bugs:
+    - Fixed an issue where sandbox crashes for large response body
 5.1.1:
   date: 2024-08-01
   fixed bugs:

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,6 @@
 unreleased:
   fixed bugs:
-    - Fixed an issue where sandbox crashes for large response body
+    - GH-1034 Fixed an issue where sandbox crashes for large response body
 5.1.1:
   date: 2024-08-01
   fixed bugs:

--- a/lib/sandbox/postman-legacy-interface.js
+++ b/lib/sandbox/postman-legacy-interface.js
@@ -71,7 +71,9 @@ const _ = require('lodash'),
         URLENCODED: 'urlencoded',
         FORMDATA: 'formdata',
         FILE: 'file'
-    };
+    },
+
+    MAX_RESPONSE_SIZE = 50 * 1024 * 1024; // 50MB
 
 function getRequestBody (request) {
     var mode = _.get(request, 'body.mode'),
@@ -416,7 +418,15 @@ module.exports = {
              * @memberOf SandboxGlobals
              * @type {String}
              */
-            globalvars.responseBody = execution.response ? execution.response.text() : undefined;
+            globalvars.responseBody = (() => {
+                // Truncating response body if it is too large to avoid negatively affecting
+                //  the performance since this get calculated for every execution by default
+                if (!execution.response || execution.response.responseSize > MAX_RESPONSE_SIZE) {
+                    return;
+                }
+
+                return execution.response.text();
+            })();
         }
 
         // 5. add the iteration information

--- a/test/unit/sandbox-libraries/legacy.test.js
+++ b/test/unit/sandbox-libraries/legacy.test.js
@@ -116,4 +116,46 @@ describe('sandbox library - legacy', function () {
             done();
         });
     });
+
+    it('should support "responseBody" with size upto 50MB', function (done) {
+        context.execute({
+            listen: 'test',
+            script: `
+                const assert = require('assert');
+                assert.strictEqual(
+                    responseBody,
+                    Buffer.alloc(50 * 1024 * 1024, 'a').toString(),
+                    'responseBody <= 50MB should be available'
+                );
+            `
+        }, {
+            context: {
+                response: {
+                    stream: {
+                        type: 'Base64',
+                        data: Buffer.alloc(50 * 1024 * 1024, 'a').toString('base64')
+                    }
+                }
+            }
+        }, done);
+    });
+
+    it('should truncate "responseBody" with size > 50MB', function (done) {
+        context.execute({
+            listen: 'test',
+            script: `
+                const assert = require('assert');
+                assert.strictEqual(typeof responseBody, 'undefined', 'responseBody > 50MB should not be available');
+            `
+        }, {
+            context: {
+                response: {
+                    stream: {
+                        type: 'Base64',
+                        data: Buffer.alloc(51 * 1024 * 1024, 'a').toString('base64')
+                    }
+                }
+            }
+        }, done);
+    });
 });


### PR DESCRIPTION
## Issue

When setting up the legacy sandbox, the response buffer is, by default, converted to a string to support the global variable `responseBody`. This negatively affects the script execution performance for consumers who are not even consuming this value.

## Fix
The ideal fix for this would be to lazily initialize `responseBody` through a getter, but due to how Uniscope is implemented, it is not possible to achieve that without a significant refactoring there (TLDR; the getter would get called at multiple places inside Uniscope).

The second best approach is to truncate the `responseBody` if it is too large (50MB). Since this is a deprecated syntax, users can (and should) use `pm.response.text()` for their requirements.