### PR TITLE
improv: only allow `pm.vault.get` and `pm.vault.set` to access vault secrets in scripts

### DIFF
--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -128,7 +128,14 @@ function Postman (execution, onRequest, onSkipRequest, onAssertion, cookieStore,
         /**
          * @type {VariableScope}
          */
-        vault: execution.vaultSecrets,
+        vault: {
+            get: (key) => {
+                return execution.vaultSecrets.get(key);
+            },
+            set: (key, value) => {
+                return execution.vaultSecrets.set(key, value);
+            }
+        },
 
         /**
          * @type {VariableScope}

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -63,7 +63,6 @@ function Postman (execution, onRequest, onSkipRequest, onAssertion, cookieStore,
     execution._variables.addLayer(execution.environment.values);
     execution._variables.addLayer(execution.collectionVariables.values);
     execution._variables.addLayer(execution.globals.values);
-    execution._variables.addLayer(execution.vaultSecrets.values);
 
     execution.cookies && (execution.cookies.jar = function () {
         return new PostmanCookieJar(cookieStore);

--- a/test/unit/pm-variables-tracking.test.js
+++ b/test/unit/pm-variables-tracking.test.js
@@ -26,10 +26,21 @@ describe('pm api variables', function () {
                 assert.equal(pm.collectionVariables.mutations.count(), 0);
                 pm.collectionVariables.set('foo', 'foo');
                 assert.equal(pm.collectionVariables.mutations.count(), 1);
+            `, {
+                context: {
+                    vaultSecrets: {} // enable pm.vault
+                }
+            }, done);
+        });
+    });
 
-                assert.equal(pm.vault.mutations.count(), 0);
-                pm.vault.set('foo', 'foo');
-                assert.equal(pm.vault.mutations.count(), 1);
+    it('should not support tracking options in scripts for vault', function (done) {
+        Sandbox.createContext({ debug: true }, function (err, ctx) {
+            if (err) { return done(err); }
+
+            ctx.execute(`
+                var assert = require('assert');
+                assert.equal(pm.vault.mutations, undefined);
             `, {
                 context: {
                     vaultSecrets: {} // enable pm.vault

--- a/test/unit/pm-variables.test.js
+++ b/test/unit/pm-variables.test.js
@@ -178,7 +178,6 @@ describe('pm.variables', function () {
                     'key-3': 'value-3',
                     'key-4': 'value-4',
                     'key-5': 'value-5',
-                    'vault:key-0': 'value-0',
                     'vault:key-1': 'value-1'
                 });
             `, {
@@ -210,7 +209,6 @@ describe('pm.variables', function () {
 
             ctx.execute(`
                 var assert = require('assert');
-                assert.strictEqual(pm.variables.get('vault:key-0'), 'value-0');
                 assert.strictEqual(pm.variables.get('key-1'), 'value-1');
                 assert.strictEqual(pm.variables.get('key-2'), 'value-2');
                 assert.strictEqual(pm.variables.get('key-3'), 'value-3');

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -311,14 +311,12 @@ describe('sandbox library - pm api', function () {
             `, { context: sampleContextData }, done);
         });
 
-        it('pm.variables.toObject must contain vaultSecrets', function (done) {
+        it('pm.variables.toObject must not contain vaultSecrets', function (done) {
             context.execute(`
                 var assert = require('assert');
 
                 assert.strictEqual(_.isPlainObject(pm.variables.toObject()), true);
                 assert.deepEqual(pm.variables.toObject(), {
-                    'vault:var1': 'one-vault',
-                    'vault:var2': 'two-vault',
                     'var1': 'one-data',
                     'var2': 2.5
                 });

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -284,11 +284,10 @@ describe('sandbox library - pm api', function () {
             `, done);
         });
 
-        it('should be defined as VariableScope', function (done) {
+        it('should only have get and set properties', function (done) {
             context.execute(`
-                var assert = require('assert'),
-                    VariableScope = require('postman-collection').VariableScope;
-                assert.strictEqual(VariableScope.isVariableScope(pm.vault), true);
+                var assert = require('assert');
+                assert.deepEqual(Object.keys(pm.vault), ['get', 'set']);
             `, { context: sampleContextData }, done);
         });
 
@@ -312,17 +311,6 @@ describe('sandbox library - pm api', function () {
             `, { context: sampleContextData }, done);
         });
 
-        it('pm.vault.toObject must return a pojo', function (done) {
-            context.execute(`
-                var assert = require('assert');
-
-                assert.strictEqual(_.isPlainObject(pm.vault.toObject()), true);
-                assert.deepEqual(pm.vault.toObject(), {
-                    'vault:var1': 'one-vault',
-                    'vault:var2': 'two-vault'
-                });
-            `, { context: sampleContextData }, done);
-        });
         it('pm.variables.toObject must contain vaultSecrets', function (done) {
             context.execute(`
                 var assert = require('assert');


### PR DESCRIPTION
## What does this change do?
- Updates the `pm.vault` export to only support `get` and `set` methods in scripts in sandbox
- Remove the layer of vaultSecrets from `pm.variables`

## How is this done?
- For only supporting `get` and `set` options, instead of exporting `pm.vault` as the VariableScope of vault secrets, we export `pm.vault` as a new object which only supports the `get` and `set` method. These methods internally call the VariableScope methods.
- For removing vault secrets from variables, we simply remove the line adding vault secrets to the variable layer

## How is this change tested
- Added/Updated unit tests for the following scenarios
    - `pm.vault` only has `get` and `set` methods
    - `pm.variables` does not include vault secrets
