### PR TITLE
Enhance pm.vault API with improved get and set methods

### DIFF
--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -144,7 +144,7 @@ function Postman (execution, onRequest, onSkipRequest, onAssertion, cookieStore,
          * @name Vault#set
          * @param {string} key -
          * @param {string} value -
-         * @returns {Promise<void>}
+         * @returns {Promise<string>}
         */
         /**
          * Unset a value in the vault.

--- a/lib/sandbox/vault.js
+++ b/lib/sandbox/vault.js
@@ -33,11 +33,11 @@ class Vault {
 const getVaultInterface = (vault) => {
     return {
         get: (key) => {
-            return vault('get', key);
+            return vault('get', key).then((value) => { return (value === null ? undefined : value); });
         },
 
         set: (key, value) => {
-            return vault('set', key, value);
+            return vault('set', key, value).then(() => { return value; });
         },
 
         unset: (key) => {

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -322,6 +322,28 @@ describe('sandbox library - pm api', function () {
             `, { id: executionId });
         });
 
+        it('should return a promise for all vault operations', function (done) {
+            context.execute(`
+                var assert = require('assert');
+                assert.strictEqual(pm.vault.get('key') instanceof Promise, true);
+                assert.strictEqual(pm.vault.set('key', 'value') instanceof Promise, true);
+                assert.strictEqual(pm.vault.unset('key') instanceof Promise, true);
+            `, {
+                context: {
+                    vaultSecrets: {}
+                }
+            }, done);
+        });
+
+        it('should not allow access to pm.vault when vaultSecrets is not set', function (done) {
+            context.execute(`
+                var assert = require('assert');
+                assert.strictEqual(typeof pm.vault, 'undefined');
+            `, {
+                context: {}
+            }, done);
+        });
+
         it('should dispatch and wait for `execution.vault.id` event when pm.vault.set is called', function (done) {
             const executionId = '2';
 

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -399,6 +399,61 @@ describe('sandbox library - pm api', function () {
         });
     });
 
+    it('should return undefined for null values in get method', function (done) {
+        const executionId = '3';
+
+        context.on('execution.vault.' + executionId, (eventId, cmd, k) => {
+            expect(eventId).to.be.ok;
+            expect(cmd).to.eql('get');
+            expect(k).to.eql('nullKey');
+
+            context.dispatch(`execution.vault.${executionId}`, eventId, null, null);
+        });
+        context.execute(`
+            const val = await pm.vault.get('nullKey');
+            pm.test('vault.get with null value', function () {
+                pm.expect(val).to.be.undefined;
+            });
+        `, { id: executionId }, done);
+    });
+
+    it('should return the value for non-null values in get method', function (done) {
+        const executionId = '4';
+
+        context.on('execution.vault.' + executionId, (eventId, cmd, k) => {
+            expect(eventId).to.be.ok;
+            expect(cmd).to.eql('get');
+            expect(k).to.eql('nonNullKey');
+
+            context.dispatch(`execution.vault.${executionId}`, eventId, null, 'nonNullValue');
+        });
+        context.execute(`
+            const val = await pm.vault.get('nonNullKey');
+            pm.test('vault.get with non-null value', function () {
+                pm.expect(val).to.equal('nonNullValue');
+            });
+        `, { id: executionId }, done);
+    });
+
+    it('should return the set value in set method', function (done) {
+        const executionId = '5';
+
+        context.on('execution.vault.' + executionId, (eventId, cmd, k, v) => {
+            expect(eventId).to.be.ok;
+            expect(cmd).to.eql('set');
+            expect(k).to.eql('testKey');
+            expect(v).to.eql('testValue');
+
+            context.dispatch(`execution.vault.${executionId}`, eventId, null);
+        });
+        context.execute(`
+            const val = await pm.vault.set('testKey', 'testValue');
+            pm.test('vault.set return value', function () {
+                pm.expect(val).to.equal('testValue');
+            });
+        `, { id: executionId }, done);
+    });
+
     describe('request', function () {
         it('should be defined as sdk Request object', function (done) {
             context.execute(`


### PR DESCRIPTION
This PR modifies the pm.vault API to enhance its functionality and improve type safety. 

The main changes are:

1. Modified get method:
- Now returns undefined instead of null when a key is not found
- Improves consistency with JavaScript's behavior for non-existent object properties

2. Modified set method:
- Now returns the value that was set
- Allows for easier chaining and verification of set operations

3. Updated type definitions:
- set method now returns Promise<string> instead of Promise<void>

4. Added new tests:
- Verify that all vault operations return promises
- Ensure pm.vault is not accessible when vaultSecrets is not set