### PR TITLE
add missing Execution.skipRequest

### DIFF
--- a/types/sandbox/test.d.ts
+++ b/types/sandbox/test.d.ts
@@ -258,6 +258,11 @@ declare interface Execution {
      * @param request - name of the request to run next
      */
     setNextRequest(request: string | null): void;
+
+    /**
+     * TODO copy the documentation from postman
+     */ 
+    skipRequest(): void
 }
 
 declare interface ExecutionLocation extends Array {


### PR DESCRIPTION
Kind of misusing this PR as one cannot create issues or discussions in the repo.
The type definition seems to be outdated. It misses certain features such as the shown skipRequest but also other things seem to be broken:

    Postman.request should also include Request (i.e. be defined as request: Request & import("postman-collection").Request;)
    same for response,
    cookies should also extend PropertyList

and probably more. As Postman itself has all the code completion, I guess there already exists an update version somewhere. Would be nice if it is published here as well
