### PR TITLE
APICLIENT-3134: security: canonicalize pm.require name and fix multi-colon package classification

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+unreleased:
+  fixed bugs:
+    - >-
+      GH-1109 Canonicalized `pm.require` package names and fixed external
+      package classification for multi-colon package names
+
 6.7.0:
   date: 2026-05-05
   new features:

--- a/lib/sandbox/pm-require.js
+++ b/lib/sandbox/pm-require.js
@@ -5,7 +5,11 @@ const { LEGACY_GLOBS } = require('./postman-legacy-interface'),
         '((exports, module) => {\n',
         `\n})(${MODULE_KEY}.exports, ${MODULE_KEY});`
     ],
-    PACKAGE_TYPE_REGEX = /^[^:]+:[^:]+$/,
+    // Matches a leading `registry:` prefix followed by a package specifier.
+    // The specifier may itself contain colons (e.g. `npm:pkg:subpath`), so we
+    // only anchor on the registry segment and allow anything after the first
+    // colon. Anchoring both ends keeps the classification total.
+    PACKAGE_TYPE_REGEX = /^[^:]+:.+$/,
 
     // This is used to determine if the package is external or internal.
     // External packages are those that are not part of the Postman's
@@ -118,16 +122,22 @@ function createPostmanRequire (fileCache, scope) {
      * @returns {any} - module
      */
     function postmanRequire (name) {
-        const path = store.getResolvedPath(name);
+        // Coerce the requested name to a string exactly once. A caller-supplied
+        // object with a stateful `toString()` could otherwise return different
+        // values across the multiple coercions below, letting the external
+        // classification disagree with the package that actually gets loaded
+        // (and poisoning the cache under an attacker-influenced key).
+        const canonicalName = String(name),
+            path = store.getResolvedPath(canonicalName);
 
         if (!path) {
             // Error should contain the name exactly as the user specified,
             // and not the resolved path.
-            throw new Error(`Cannot find package '${name}'`);
+            throw new Error(`Cannot find package '${canonicalName}'`);
         }
 
         if (store.hasError(path)) {
-            throw new Error(`Error while loading package '${name}': ${store.getFileError(path)}`);
+            throw new Error(`Error while loading package '${canonicalName}': ${store.getFileError(path)}`);
         }
 
         // Any module should not be evaluated twice, so we use it from the
@@ -168,13 +178,13 @@ function createPostmanRequire (fileCache, scope) {
         //   - We want to allow execution of async code like setTimeout etc.
         scope.exec(wrappedModule, {
             async: true,
-            block: isExternalPackage(name) ?
+            block: isExternalPackage(canonicalName) ?
                 LEGACY_GLOBS.concat('pm') :
                 LEGACY_GLOBS
         }, (err) => {
             // Bubble up the error to be caught as execution error
             if (err) {
-                throw new Error(`Error in package '${name}': ${err.message ? err.message : err}`);
+                throw new Error(`Error in package '${canonicalName}': ${err.message ? err.message : err}`);
             }
         });
 


### PR DESCRIPTION
## Summary

`pm.require(name)` in `lib/sandbox/pm-require.js` did not canonicalize `name` to a string before using it. The value was coerced independently at multiple sites (path resolution, cache key, and the `isExternalPackage()` classification that decides whether the `pm` global is blocked). A caller-supplied object whose `toString()` returns different values across those coercions could make the external/internal classification disagree with the package actually loaded, so an external package could execute with full `pm` access. The coerced value was also used as the cache key, allowing cache aliasing so a later trusted `pm.require(...)` could return attacker-controlled exports.

Separately, `PACKAGE_TYPE_REGEX` only matched names with exactly one colon (`/^[^:]+:[^:]+$/`). Multi-colon names such as `npm:pkg:subpath` failed the test and were mis-classified as internal, bypassing the external isolation (the `pm` block).


## Fix

- Coerce `name` to a string exactly once at the top of `postmanRequire` (`const canonicalName = String(name)`) and use `canonicalName` at every subsequent site: `getResolvedPath`, all error messages, and `isExternalPackage`. The cache key/module id continue to derive from the resolved `path`, which is now a function of the single canonical value, eliminating the aliasing.
- Change `PACKAGE_TYPE_REGEX` to `/^[^:]+:.+$/` so a `registry:` prefix followed by any specifier (including additional colons, e.g. `npm:pkg:subpath`) is correctly classified as external.

## Risk

Low, minimal and behavior-preserving for well-formed string inputs. String names resolve and classify exactly as before. The only behavior changes are (a) object inputs are now stably coerced once, and (b) multi-colon `registry:...` names are now classified external (blocking `pm`) as intended.

## Test plan

- `node --check lib/sandbox/pm-require.js` passes. Repo lint/test toolchain (`npm run test-lint`) not run in this environment (dependencies not installed).
- Recommend running `npm run test-lint` and the VM/unit suites in CI. Suggested additions: a `pm.require` called with an object whose `toString()` mutates between calls resolves/classifies consistently; and `npm:pkg:subpath` is treated as external (no `pm` access).

Linked Jira: APICLIENT-3134

Generated with [Claude Code](https://claude.com/claude-code)