### PR TITLE
Consume streamed dataset rows via the pull protocol

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,5 +1,6 @@
 unreleased:
   chores:
+    - GH-1110 Added support for streaming `pm.datasets` results
     - Updated dependencies
 
 6.7.2:

--- a/lib/sandbox/datasets.js
+++ b/lib/sandbox/datasets.js
@@ -25,6 +25,39 @@ class Datasets {
         });
     }
 
+    /**
+     * Async generator that pulls rows one batch at a time from the host, keeping
+     * memory bounded end to end. Each `__pull` is a request/response over the
+     * existing bridge; the host serves the next batch from the open engine
+     * cursor it holds for `streamId`, marking `done` on the final frame. If the
+     * consumer stops early (breaks the `for await`), `__cancel` releases the
+     * host-side cursor.
+     */
+    streamRows (streamId) {
+        const self = this;
+
+        return (async function *() {
+            let done = false;
+
+            try {
+                while (!done) {
+                    const frame = await self.exec('__pull', streamId),
+                        rows = (frame && frame.rows) || [];
+
+                    for (let i = 0; i < rows.length; i++) {
+                        yield rows[i];
+                    }
+
+                    done = Boolean(frame && frame.done);
+                }
+            }
+            finally {
+                // Best-effort release when the consumer breaks before `done`.
+                if (!done) { self.exec('__cancel', streamId).catch(() => { /* noop */ }); }
+            }
+        })();
+    }
+
     dispose () {
         this._bridge.off(this._event, this._handler);
     }
@@ -36,11 +69,17 @@ async function *iterateRows (rows) {
     }
 }
 
-function wrapQueryResult (result) {
-    const safeRows = result && Array.isArray(result.rows) ? result.rows : [],
+function wrapQueryResult (result, datasets) {
+    const rows = result && result.rows,
         wrapped = {
             columns: (result && result.columns) || [],
-            rows: iterateRows(safeRows)
+            // Streaming reply: the host sends a head frame `{ columns, streaming,
+            // streamId }` and serves rows on demand via `__pull`. Non-streaming
+            // reply: rows is a materialised array (back-compat). Either way the
+            // script sees the same `AsyncIterable`.
+            rows: result && result.streaming ?
+                datasets.streamRows(result.streamId) :
+                iterateRows(Array.isArray(rows) ? rows : [])
         };
 
     if (result && result.staleDatasources) {
@@ -54,15 +93,15 @@ const getDatasetsInterface = (datasets) => {
     return function (datasetId) {
         return {
             executeView: async (viewId, params) => {
-                const result = await datasets('executeView', datasetId, viewId, params);
+                const result = await datasets.exec('executeView', datasetId, viewId, params);
 
-                return wrapQueryResult(result);
+                return wrapQueryResult(result, datasets);
             },
 
             executeQuery: async (sql, params) => {
-                const result = await datasets('executeQuery', datasetId, sql, params);
+                const result = await datasets.exec('executeQuery', datasetId, sql, params);
 
-                return wrapQueryResult(result);
+                return wrapQueryResult(result, datasets);
             }
         };
     };

--- a/lib/sandbox/datasets.js
+++ b/lib/sandbox/datasets.js
@@ -32,6 +32,9 @@ class Datasets {
      * cursor it holds for `streamId`, marking `done` on the final frame. If the
      * consumer stops early (breaks the `for await`), `__cancel` releases the
      * host-side cursor.
+     *
+     * @param {String} streamId - identifies the open host-side cursor to pull from
+     * @returns {AsyncGenerator} - yields one row object at a time until `done`
      */
     streamRows (streamId) {
         const self = this;
@@ -41,6 +44,9 @@ class Datasets {
 
             try {
                 while (!done) {
+                    // Batches are pulled sequentially — each __pull advances the
+                    // one host-side cursor, so the await must serialize.
+                    // eslint-disable-next-line no-await-in-loop
                     const frame = await self.exec('__pull', streamId),
                         rows = (frame && frame.rows) || [];
 
@@ -55,7 +61,7 @@ class Datasets {
                 // Best-effort release when the consumer breaks before `done`.
                 if (!done) { self.exec('__cancel', streamId).catch(() => { /* noop */ }); }
             }
-        })();
+        }());
     }
 
     dispose () {

--- a/lib/sandbox/datasets.js
+++ b/lib/sandbox/datasets.js
@@ -47,7 +47,7 @@ class Datasets {
                     // Batches are pulled sequentially — each __pull advances the
                     // one host-side cursor, so the await must serialize.
                     // eslint-disable-next-line no-await-in-loop
-                    const frame = await self.exec('__pull', streamId),
+                    const frame = await self.exec('__pull', null, streamId),
                         rows = (frame && frame.rows) || [];
 
                     for (let i = 0; i < rows.length; i++) {
@@ -59,7 +59,7 @@ class Datasets {
             }
             finally {
                 // Best-effort release when the consumer breaks before `done`.
-                if (!done) { self.exec('__cancel', streamId).catch(() => { /* noop */ }); }
+                if (!done) { self.exec('__cancel', null, streamId).catch(() => { /* noop */ }); }
             }
         }());
     }

--- a/lib/sandbox/datasets.js
+++ b/lib/sandbox/datasets.js
@@ -1,37 +1,63 @@
+const EXECUTION_DATASETS_EVENT_BASE = 'execution.datasets.',
+    EXECUTION_DATASETS_STREAM_EVENT_BASE = 'execution.datasets.stream.';
+
 class Datasets {
     constructor (id, bridge, timers) {
         this._bridge = bridge;
         this._timers = timers;
-        this._event = `execution.datasets.${id}`;
+
+        // Dataset commands: `(cmd, datasetId, ...args)`.
+        this._event = EXECUTION_DATASETS_EVENT_BASE + id;
+
+        // Stream control: `(action, streamId)`, on its own channel.
+        this._streamEvent = EXECUTION_DATASETS_STREAM_EVENT_BASE + id;
 
         this._handler = (eventId, ...args) => {
             this._timers.clearEvent(eventId, ...args);
         };
 
         this._bridge.on(this._event, this._handler);
+        this._bridge.on(this._streamEvent, this._handler);
     }
 
+    /**
+     * Run a dataset command on the host.
+     *
+     * @param {...*} args - `(cmd, datasetId, ...cmdArgs)`
+     * @returns {Promise} resolves with the host's reply
+     */
     exec (...args) {
+        return this._request(this._event, args);
+    }
+
+    /**
+     * Dispatch on `event` and resolve with the host's reply, correlated by event id.
+     *
+     * @private
+     * @param {String} event - the bridge channel to dispatch on
+     * @param {Array} args - arguments to forward after the event id
+     * @returns {Promise} resolves with the host's reply, rejects with its error
+     */
+    _request (event, args) {
         return new Promise((resolve, reject) => {
-            const eventId = this._timers.setEvent((err, ...args) => {
+            const eventId = this._timers.setEvent((err, ...result) => {
                 if (err) {
                     return reject(err instanceof Error ? err : new Error(err.message || err));
                 }
 
-                resolve(...args);
+                resolve(...result);
             });
 
-            this._bridge.dispatch(this._event, eventId, ...args);
+            this._bridge.dispatch(event, eventId, ...args);
         });
     }
 
     /**
      * Async generator that pulls rows one batch at a time from the host, keeping
-     * memory bounded end to end. Each `__pull` is a request/response over the
-     * existing bridge; the host serves the next batch from the open engine
-     * cursor it holds for `streamId`, marking `done` on the final frame. If the
-     * consumer stops early (breaks the `for await`), `__cancel` releases the
-     * host-side cursor.
+     * memory bounded end to end. Each pull is a request/response on the stream
+     * channel; the host serves the next batch from the open engine cursor it holds
+     * for `streamId` and marks `done` on the final frame. If the consumer stops
+     * early (breaks the `for await`), a cancel releases that cursor.
      *
      * @param {String} streamId - identifies the open host-side cursor to pull from
      * @returns {AsyncGenerator} - yields one row object at a time until `done`
@@ -40,32 +66,42 @@ class Datasets {
         const self = this;
 
         return (async function *() {
+            if (!streamId) {
+                throw new Error('pm.datasets: streamed result is missing a stream id');
+            }
+
             let done = false;
 
             try {
                 while (!done) {
-                    // Batches are pulled sequentially — each __pull advances the
-                    // one host-side cursor, so the await must serialize.
+                    // Batches are pulled sequentially — each pull advances the one
+                    // host-side cursor, so the await must serialize.
                     // eslint-disable-next-line no-await-in-loop
-                    const frame = await self.exec('__pull', null, streamId),
+                    const frame = await self._request(self._streamEvent, ['pull', streamId]),
                         rows = (frame && frame.rows) || [];
+
+                    // Read `done` before yielding: a consumer that breaks part-way
+                    // through the final frame must not then cancel a stream the host
+                    // has already closed.
+                    done = Boolean(frame && frame.done);
 
                     for (let i = 0; i < rows.length; i++) {
                         yield rows[i];
                     }
-
-                    done = Boolean(frame && frame.done);
                 }
             }
             finally {
                 // Best-effort release when the consumer breaks before `done`.
-                if (!done) { self.exec('__cancel', null, streamId).catch(() => { /* noop */ }); }
+                if (!done) {
+                    self._request(self._streamEvent, ['cancel', streamId]).catch(() => { /* noop */ });
+                }
             }
         }());
     }
 
     dispose () {
         this._bridge.off(this._event, this._handler);
+        this._bridge.off(this._streamEvent, this._handler);
     }
 }
 
@@ -80,9 +116,9 @@ function wrapQueryResult (result, datasets) {
         wrapped = {
             columns: (result && result.columns) || [],
             // Streaming reply: the host sends a head frame `{ columns, streaming,
-            // streamId }` and serves rows on demand via `__pull`. Non-streaming
-            // reply: rows is a materialised array (back-compat). Either way the
-            // script sees the same `AsyncIterable`.
+            // streamId }` and serves rows on demand over the stream channel.
+            // Non-streaming reply: rows is a materialised array (back-compat).
+            // Either way the script sees the same `AsyncIterable`.
             rows: result && result.streaming ?
                 datasets.streamRows(result.streamId) :
                 iterateRows(Array.isArray(rows) ? rows : [])
@@ -95,7 +131,7 @@ function wrapQueryResult (result, datasets) {
     return wrapped;
 }
 
-const getDatasetsInterface = (datasets) => {
+function getDatasetsInterface (datasets) {
     return function (datasetId) {
         return {
             executeView: async (viewId, params) => {
@@ -111,7 +147,7 @@ const getDatasetsInterface = (datasets) => {
             }
         };
     };
-};
+}
 
 module.exports = {
     Datasets,

--- a/lib/sandbox/execute.js
+++ b/lib/sandbox/execute.js
@@ -372,7 +372,7 @@ module.exports = function (bridge, glob) {
                     dispatchAssertions,
                     new PostmanCookieStore(id, bridge, timers),
                     getVaultInterface(vault.exec.bind(vault)),
-                    getDatasetsInterface(datasets.exec.bind(datasets)),
+                    getDatasetsInterface(datasets),
                     function onRunCollectionRequest (requestToRunId, requestOptions, callback) {
                         const eventId = timers.setEvent(callback),
                             context = {};

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -610,7 +610,7 @@ describe('sandbox library - pm api', function () {
                 });
                 done();
             });
-            context.on('execution.datasets.' + executionId, (eventId, cmd, arg) => {
+            context.on('execution.datasets.' + executionId, (eventId, cmd, datasetId, streamId) => {
                 const ev = 'execution.datasets.' + executionId;
 
                 if (cmd === 'executeQuery') {
@@ -619,7 +619,8 @@ describe('sandbox library - pm api', function () {
                         { columns: ['id', 'name'], streaming: true, streamId: 's1' });
                 }
                 else if (cmd === '__pull') {
-                    expect(arg).to.eql('s1');
+                    // streamId now rides in its own arg, not the datasetId slot.
+                    expect(streamId).to.eql('s1');
                     const idx = pull++,
                         batch = batches[idx] || [];
 

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -473,6 +473,173 @@ describe('sandbox library - pm api', function () {
             `, { id: executionId });
         });
 
+        it('should multiplex multiple in-flight queries when host dispatches in setTimeout', function (done) {
+            const executionId = '2',
+                // SQL string -> result. Used to (a) decide what to dispatch back
+                // and (b) decide how long to delay so responses arrive in a
+                // different order than they were issued from the script.
+                responses = {
+                    q1: { columns: ['x'], rows: [{ x: 1 }, { x: 2 }, { x: 3 }] },
+                    q2: { columns: ['y'], rows: [{ y: 'a' }, { y: 'b' }] },
+                    q3: { columns: ['z'], rows: [{ z: true }] }
+                },
+                delays = { q1: 30, q2: 5, q3: 15 };
+
+            context.on('execution.error', done);
+            context.on('execution.assertion', function (cursor, assertion) {
+                assertion.forEach(function (ass) {
+                    expect(ass).to.deep.include({ passed: true, error: null });
+                });
+                done();
+            });
+            context.on('execution.datasets.' + executionId, (eventId, cmd, datasetId, sql) => {
+                // Stagger the host-side dispatches via setTimeout so responses
+                // arrive out of issue order. Verifies that:
+                //   1. Each promise resolves with its own result (eventId
+                //      correlation works under concurrency).
+                //   2. The async iterable inside each result is independent —
+                //      consuming r2.rows doesn't interfere with r1.rows etc.
+                setTimeout(() => {
+                    context.dispatch(`execution.datasets.${executionId}`,
+                        eventId, null, responses[sql]);
+                }, delays[sql]);
+            });
+            context.execute(`
+                const [r1, r2, r3] = await Promise.all([
+                    pm.datasets('ds-123').executeQuery('q1'),
+                    pm.datasets('ds-123').executeQuery('q2'),
+                    pm.datasets('ds-123').executeQuery('q3')
+                ]);
+                const c1 = [], c2 = [], c3 = [];
+                for await (const row of r1.rows) { c1.push(row); }
+                for await (const row of r2.rows) { c2.push(row); }
+                for await (const row of r3.rows) { c3.push(row); }
+                pm.test('multiple in-flight queries each get their own iterable', function () {
+                    pm.expect(r1.columns).to.eql(['x']);
+                    pm.expect(c1).to.eql([{ x: 1 }, { x: 2 }, { x: 3 }]);
+                    pm.expect(r2.columns).to.eql(['y']);
+                    pm.expect(c2).to.eql([{ y: 'a' }, { y: 'b' }]);
+                    pm.expect(r3.columns).to.eql(['z']);
+                    pm.expect(c3).to.eql([{ z: true }]);
+                });
+            `, { id: executionId });
+        });
+
+        // eslint-disable-next-line @stylistic/js/max-len
+        it('should stream rows row-by-row through the async iterable while host dispatches happen in setTimeout', function (done) {
+            const executionId = '2',
+                // Distinct row shapes per query so cross-contamination is detectable.
+                firstRows = Array.from({ length: 25 }, function (_, i) { return { idx: i, source: 'first' }; }),
+                secondRows = Array.from({ length: 10 }, function (_, i) { return { idx: i, source: 'second' }; });
+
+            context.on('execution.error', done);
+            context.on('execution.assertion', function (cursor, assertion) {
+                assertion.forEach(function (ass) {
+                    expect(ass).to.deep.include({ passed: true, error: null });
+                });
+                done();
+            });
+            context.on('execution.datasets.' + executionId, (eventId, cmd, datasetId, sql) => {
+                // 'fast' resolves quickly; 'slow' resolves while the sandbox
+                // is already mid-iteration of the first iterable. Both go
+                // through setTimeout so dispatches happen on a later
+                // host-side tick than the corresponding script-side request.
+                const payload = sql === 'fast' ?
+                        { columns: ['idx', 'source'], rows: firstRows } :
+                        { columns: ['idx', 'source'], rows: secondRows },
+                    delay = sql === 'fast' ? 1 : 30;
+
+                setTimeout(() => {
+                    context.dispatch(`execution.datasets.${executionId}`, eventId, null, payload);
+                }, delay);
+            });
+            context.execute(`
+                // Resolve the first query; its iterable will be drained row-by-row.
+                const r1 = await pm.datasets('ds').executeQuery('fast');
+
+                // Issue the second query but DON'T await it yet — its host
+                // dispatch (in setTimeout, ~30ms) must arrive while we are
+                // already suspended inside the first iterator's for-await
+                // loop.
+                const r2Promise = pm.datasets('ds').executeQuery('slow');
+
+                // Stream rows one-by-one with an explicit await between each
+                // iteration. This forces the async generator to suspend and
+                // resume across event-loop ticks while another in-flight
+                // query is mid-flight.
+                const collectedFirst = [];
+                for await (const row of r1.rows) {
+                    collectedFirst.push(row);
+                    await new Promise((resolve) => setTimeout(resolve, 2));
+                }
+
+                // The second query's response was dispatched at ~30ms — well
+                // before the first iterable finished (25 rows x 2ms = 50ms+).
+                // Awaiting it now should resolve immediately.
+                const r2 = await r2Promise;
+                const collectedSecond = [];
+                for await (const row of r2.rows) {
+                    collectedSecond.push(row);
+                }
+
+                pm.test('streaming rows survives per-row suspension and parallel in-flight query', function () {
+                    // First iterable — drained row-by-row across event-loop ticks.
+                    pm.expect(collectedFirst).to.have.lengthOf(25);
+                    pm.expect(collectedFirst[0]).to.eql({ idx: 0, source: 'first' });
+                    pm.expect(collectedFirst[24]).to.eql({ idx: 24, source: 'first' });
+                    pm.expect(collectedFirst.every((r) => r.source === 'first')).to.be.true;
+                    // Second iterable — its host dispatch arrived mid-stream; rows
+                    // didn't bleed into the first iterable.
+                    pm.expect(collectedSecond).to.have.lengthOf(10);
+                    pm.expect(collectedSecond[0]).to.eql({ idx: 0, source: 'second' });
+                    pm.expect(collectedSecond.every((r) => r.source === 'second')).to.be.true;
+                });
+            `, { id: executionId });
+        });
+
+        it('should stream rows via the pull protocol (head frame + __pull batches)', function (done) {
+            const executionId = '2',
+                batches = [[{ id: 1, name: 'A' }, { id: 2, name: 'B' }], [{ id: 3, name: 'C' }]];
+
+            let pull = 0;
+
+            context.on('execution.error', done);
+            context.on('execution.assertion', function (cursor, assertion) {
+                assertion.forEach(function (ass) {
+                    expect(ass).to.deep.include({ passed: true, error: null });
+                });
+                done();
+            });
+            context.on('execution.datasets.' + executionId, (eventId, cmd, arg) => {
+                const ev = 'execution.datasets.' + executionId;
+
+                if (cmd === 'executeQuery') {
+                    // Head frame: columns up front + streaming marker; rows follow via __pull.
+                    context.dispatch(ev, eventId, null,
+                        { columns: ['id', 'name'], streaming: true, streamId: 's1' });
+                }
+                else if (cmd === '__pull') {
+                    expect(arg).to.eql('s1');
+                    const idx = pull++,
+                        batch = batches[idx] || [];
+
+                    // done:true on the frame after the last batch.
+                    context.dispatch(ev, eventId, null, { rows: batch, done: idx >= batches.length });
+                }
+            });
+            context.execute(`
+                const result = await pm.datasets('ds-123').executeQuery('SELECT * FROM t');
+                const collected = [];
+                for await (const row of result.rows) { collected.push(row); }
+                pm.test('datasets streaming pull', function () {
+                    pm.expect(result.columns).to.eql(['id', 'name']);
+                    pm.expect(collected).to.eql([
+                        { id: 1, name: 'A' }, { id: 2, name: 'B' }, { id: 3, name: 'C' }
+                    ]);
+                });
+            `, { id: executionId });
+        });
+
         it('should trigger `execution.error` event if pm.datasets promise rejects', function (done) {
             const executionId = '2',
                 executionError = sinon.spy();

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -597,9 +597,11 @@ describe('sandbox library - pm api', function () {
             `, { id: executionId });
         });
 
-        it('should stream rows via the pull protocol (head frame + __pull batches)', function (done) {
+        it('should stream rows via the pull protocol (head frame + pull batches)', function (done) {
             const executionId = '2',
-                batches = [[{ id: 1, name: 'A' }, { id: 2, name: 'B' }], [{ id: 3, name: 'C' }]];
+                batches = [[{ id: 1, name: 'A' }, { id: 2, name: 'B' }], [{ id: 3, name: 'C' }]],
+                COMMAND_EVENT = 'execution.datasets.' + executionId,
+                STREAM_EVENT = 'execution.datasets.stream.' + executionId;
 
             let pull = 0;
 
@@ -610,23 +612,27 @@ describe('sandbox library - pm api', function () {
                 });
                 done();
             });
-            context.on('execution.datasets.' + executionId, (eventId, cmd, datasetId, streamId) => {
-                const ev = 'execution.datasets.' + executionId;
+            context.on(COMMAND_EVENT, (eventId, cmd, datasetId, sql) => {
+                expect(cmd).to.equal('executeQuery');
+                expect(datasetId).to.equal('ds-123');
+                expect(sql).to.equal('SELECT * FROM t');
 
-                if (cmd === 'executeQuery') {
-                    // Head frame: columns up front + streaming marker; rows follow via __pull.
-                    context.dispatch(ev, eventId, null,
-                        { columns: ['id', 'name'], streaming: true, streamId: 's1' });
-                }
-                else if (cmd === '__pull') {
-                    // streamId now rides in its own arg, not the datasetId slot.
-                    expect(streamId).to.eql('s1');
-                    const idx = pull++,
-                        batch = batches[idx] || [];
+                // Head frame: columns up front + streaming marker; rows follow on the
+                // stream channel. `staleDatasources` rides along like any other field.
+                context.dispatch(COMMAND_EVENT, eventId, null,
+                    { columns: ['id', 'name'], streaming: true, streamId: 's1', staleDatasources: ['ds-9'] });
+            });
+            // Stream control has its own channel and its own `(action, streamId)`
+            // shape — no placeholder for the unused datasetId slot.
+            context.on(STREAM_EVENT, (eventId, action, streamId) => {
+                expect(action).to.equal('pull');
+                expect(streamId).to.equal('s1');
 
-                    // done:true on the frame after the last batch.
-                    context.dispatch(ev, eventId, null, { rows: batch, done: idx >= batches.length });
-                }
+                const idx = pull++,
+                    batch = batches[idx] || [];
+
+                // done:true on the frame after the last batch.
+                context.dispatch(STREAM_EVENT, eventId, null, { rows: batch, done: idx >= batches.length });
             });
             context.execute(`
                 const result = await pm.datasets('ds-123').executeQuery('SELECT * FROM t');
@@ -634,9 +640,80 @@ describe('sandbox library - pm api', function () {
                 for await (const row of result.rows) { collected.push(row); }
                 pm.test('datasets streaming pull', function () {
                     pm.expect(result.columns).to.eql(['id', 'name']);
+                    pm.expect(result.staleDatasources).to.eql(['ds-9']);
                     pm.expect(collected).to.eql([
                         { id: 1, name: 'A' }, { id: 2, name: 'B' }, { id: 3, name: 'C' }
                     ]);
+                });
+            `, { id: executionId });
+        });
+
+        it('should cancel the host-side stream when the script stops iterating early', function (done) {
+            const executionId = '2',
+                COMMAND_EVENT = 'execution.datasets.' + executionId,
+                STREAM_EVENT = 'execution.datasets.stream.' + executionId,
+                actions = [];
+
+            context.on('execution.error', done);
+            context.on('execution.assertion', function (cursor, assertion) {
+                assertion.forEach(function (ass) {
+                    expect(ass).to.deep.include({ passed: true, error: null });
+                });
+
+                // the `break` must have released the host-side cursor
+                expect(actions).to.eql(['pull', 'cancel']);
+                done();
+            });
+            context.on(COMMAND_EVENT, (eventId) => {
+                context.dispatch(COMMAND_EVENT, eventId, null,
+                    { columns: ['id'], streaming: true, streamId: 's1' });
+            });
+            context.on(STREAM_EVENT, (eventId, action, streamId) => {
+                actions.push(action);
+                expect(streamId).to.equal('s1');
+
+                // never `done`, so only an explicit cancel can end this stream
+                if (action === 'pull') {
+                    return context.dispatch(STREAM_EVENT, eventId, null,
+                        { rows: [{ id: 1 }, { id: 2 }, { id: 3 }], done: false });
+                }
+
+                context.dispatch(STREAM_EVENT, eventId, null, { ok: true });
+            });
+            context.execute(`
+                const result = await pm.datasets('ds-123').executeQuery('SELECT * FROM t');
+                const collected = [];
+                for await (const row of result.rows) {
+                    collected.push(row);
+                    if (collected.length === 2) { break; }
+                }
+                pm.test('datasets streaming early break', function () {
+                    pm.expect(collected).to.eql([{ id: 1 }, { id: 2 }]);
+                });
+            `, { id: executionId });
+        });
+
+        it('should error when a streaming reply carries no stream id', function (done) {
+            const executionId = '2',
+                COMMAND_EVENT = 'execution.datasets.' + executionId;
+
+            context.on('execution.assertion', function (cursor, assertion) {
+                assertion.forEach(function (ass) {
+                    expect(ass).to.deep.include({ passed: true, error: null });
+                });
+                done();
+            });
+            context.on(COMMAND_EVENT, (eventId) => {
+                // malformed head frame — streaming, but nothing to pull from
+                context.dispatch(COMMAND_EVENT, eventId, null, { columns: ['id'], streaming: true });
+            });
+            context.execute(`
+                const result = await pm.datasets('ds-123').executeQuery('SELECT * FROM t');
+                let message;
+                try { for await (const row of result.rows) { void row; } }
+                catch (e) { message = e.message; }
+                pm.test('datasets streaming without a stream id', function () {
+                    pm.expect(message).to.include('missing a stream id');
                 });
             `, { id: executionId });
         });


### PR DESCRIPTION
## What

Adds streaming support to `pm.datasets` in the sandbox. `wrapQueryResult` detects a
streaming head frame and backs `result.rows` with an async generator (`streamRows`)
that pulls row batches on demand until the host signals done, and cancels the
host-side cursor if the script stops iterating early — so scripts iterate
arbitrarily large results with flat memory.

Either way the script sees the same `AsyncIterable`, so a non-streaming
(materialised `rows` array) reply keeps working unchanged.

## Why

Part of the dataset-engine streaming stack (engine → SDK → runtime → sandbox). The
engine streams Apache Arrow batches; the SDK decodes them to rows; the runtime
relays them to the sandbox; this change lets user scripts consume them lazily.

## The wire protocol

Two channels, both keyed by execution id:

| Channel | Payload | Purpose |
|---|---|---|
| `execution.datasets.<id>` | `(cmd, datasetId, ...args)` | `executeView` / `executeQuery` |
| `execution.datasets.stream.<id>` | `(action, streamId)` | `'pull'` / `'cancel'` |

Stream control lives on its own channel with `streamId` as a first-class argument,
rather than being punned into the `datasetId` slot of the command channel. The host
replies to `executeView`/`executeQuery` with either:

- a **head frame** `{ columns, streaming: true, streamId }` — rows served on demand
  over the stream channel, or
- a **materialised** `{ columns, rows: [...] }` — the pre-existing shape.

Each `'pull'` is a request/response that returns the next batch and marks `done` on
the final frame. A generator that ran to completion must not then cancel a stream
the host has already closed, so cancel only fires on early exit.