### PR TITLE
Expose performance test output reports to scripts

### DIFF
--- a/lib/sandbox/execution.js
+++ b/lib/sandbox/execution.js
@@ -6,6 +6,7 @@ const _ = require('lodash'),
         SCRIPT: 'script',
         DATA: 'data',
         COOKIES: 'cookies',
+        REPORT: 'report',
         RESPONSE: 'response',
         MESSAGE: 'message'
     },
@@ -21,7 +22,86 @@ const _ = require('lodash'),
 
     CONTEXT_VARIABLE_SCOPES = ['_variables', 'environment', 'collectionVariables', 'globals'],
 
-    trackingOptions = { autoCompact: true };
+    trackingOptions = { autoCompact: true },
+
+    /**
+     * Creates an immutable copy of a JSON-safe value without invoking accessors.
+     *
+     * @param {*} value -
+     * @param {WeakSet<Object>} [ancestors] -
+     * @returns {*} -
+     * @throws {TypeError} When the value is not JSON-safe.
+     */
+    cloneAndFreezeJSON = function (value, ancestors = new WeakSet()) {
+        if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+            return value;
+        }
+
+        if (typeof value === 'number') {
+            if (!Number.isFinite(value)) {
+                throw new TypeError('sandbox: report contains a non-finite number');
+            }
+
+            return value;
+        }
+
+        if (!value || typeof value !== 'object') {
+            throw new TypeError('sandbox: report contains a non-JSON value');
+        }
+
+        if (ancestors.has(value)) {
+            throw new TypeError('sandbox: report contains a circular reference');
+        }
+
+        ancestors.add(value);
+
+        let clone;
+
+        if (Array.isArray(value)) {
+            clone = new Array(value.length);
+
+            for (let index = 0; index < value.length; index++) {
+                const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+
+                if (!descriptor || !Object.hasOwn(descriptor, 'value')) {
+                    throw new TypeError('sandbox: report contains a sparse array or accessor');
+                }
+
+                clone[index] = cloneAndFreezeJSON(descriptor.value, ancestors);
+            }
+
+            if (Object.keys(value).length !== value.length) {
+                throw new TypeError('sandbox: report array contains unsupported properties');
+            }
+        }
+        else {
+            const prototype = Object.getPrototypeOf(value);
+
+            if (prototype !== Object.prototype && prototype !== null) {
+                throw new TypeError('sandbox: report contains a non-plain object');
+            }
+
+            clone = {};
+            Object.keys(value).forEach((key) => {
+                const descriptor = Object.getOwnPropertyDescriptor(value, key);
+
+                if (!descriptor || !Object.hasOwn(descriptor, 'value')) {
+                    throw new TypeError('sandbox: report contains an accessor');
+                }
+
+                Object.defineProperty(clone, key, {
+                    value: cloneAndFreezeJSON(descriptor.value, ancestors),
+                    writable: true,
+                    configurable: true,
+                    enumerable: true
+                });
+            });
+        }
+
+        ancestors.delete(value);
+
+        return Object.freeze(clone);
+    };
 
 class Execution {
     constructor (id, event, context, options) {
@@ -31,6 +111,22 @@ class Execution {
         this.cursor = _.isObject(options.cursor) ? options.cursor : {};
         this.data = _.get(context, PROPERTY.DATA, {});
         this.cookies = new sdk.CookieList(null, context.cookies);
+
+        if (Object.hasOwn(context, PROPERTY.REPORT)) {
+            if (
+                context.report !== null &&
+                (!context.report || typeof context.report !== 'object' || Array.isArray(context.report))
+            ) {
+                throw new TypeError('sandbox: report must be a JSON object or null');
+            }
+
+            Object.defineProperty(this, PROPERTY.REPORT, {
+                value: context.report === null ? null : cloneAndFreezeJSON(context.report),
+                writable: false,
+                configurable: false,
+                enumerable: false
+            });
+        }
 
         CONTEXT_VARIABLE_SCOPES.forEach((variableScope) => {
             // normalize variable scope instances

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -65,7 +65,8 @@ function Postman (execution,
     requireFn,
     options = {}) {
     // @todo - ensure runtime passes data in a scope format
-    let iterationData = new VariableScope();
+    let iterationData = new VariableScope(),
+        performanceTest;
 
     iterationData.syncVariablesFrom(execution.data);
 
@@ -75,6 +76,16 @@ function Postman (execution,
     execution._variables.addLayer(execution.environment.values);
     execution._variables.addLayer(execution.collectionVariables.values);
     execution._variables.addLayer(execution.globals.values);
+
+    if (Object.hasOwn(execution, 'report')) {
+        performanceTest = Object.freeze(_assignDefinedReadonly({}, {
+            output: Object.freeze(_assignDefinedReadonly({}, {
+                report: Object.freeze(_assignDefinedReadonly({}, {
+                    json: execution.report
+                }))
+            }))
+        }));
+    }
 
     execution.cookies && (execution.cookies.jar = function () {
         return new PostmanCookieJar(cookieStore);
@@ -257,6 +268,35 @@ function Postman (execution,
          * @type {VariableScope}
          */
         iterationData: iterationData,
+
+        /**
+         * Completed main-workload report wrapper.
+         *
+         * @typedef {Object} PerformanceTestReport
+         * @property {Object.<string, *>|null} json - Deeply immutable JSON report, or `null` when unavailable.
+         */
+
+        /**
+         * Completed performance test output.
+         *
+         * @typedef {Object} PerformanceTestOutput
+         * @property {PerformanceTestReport} report - Completed main-workload report.
+         */
+
+        /**
+         * Performance-test-only APIs.
+         *
+         * @typedef {Object} PerformanceTest
+         * @property {PerformanceTestOutput} output - Completed performance test output.
+         */
+
+        /**
+         * Contains performance-test-only APIs supplied for this script execution.
+         *
+         * @type {PerformanceTest|undefined}
+         * @readonly
+         */
+        performanceTest: performanceTest,
 
         /**
          * The request object inside pm is a representation of the request for which this script is being run.

--- a/npm/build-sandbox-types.js
+++ b/npm/build-sandbox-types.js
@@ -26,6 +26,22 @@ function generateSandboxTypes (node, printer, target) {
     var source = '',
         excludeResponse = target === 'prerequest',
         collectionSDKTypesExtension = '',
+        readonlyTypeNames = new Set(['PerformanceTest', 'PerformanceTestOutput', 'PerformanceTestReport']),
+        markTypePropertiesReadonly = (node) => {
+            if (
+                !typescript.isTypeAliasDeclaration(node) ||
+                !readonlyTypeNames.has(node.name.text) ||
+                !typescript.isTypeLiteralNode(node.type)
+            ) {
+                return;
+            }
+
+            node.type.members.forEach((member) => {
+                member.modifiers = typescript.createNodeArray([
+                    typescript.createToken(typescript.SyntaxKind.ReadonlyKeyword)
+                ]);
+            });
+        },
         shouldExcludeNode = (node, target) => {
             if (!node.jsDoc || node.jsDoc.length === 0) {
                 return false;
@@ -71,6 +87,7 @@ function generateSandboxTypes (node, printer, target) {
         };
 
     node.forEachChild((child) => {
+        markTypePropertiesReadonly(child);
         source = processChild(child, target, source, printer, node);
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postman-sandbox",
-  "version": "6.7.4",
+  "version": "6.7.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "postman-sandbox",
-      "version": "6.7.4",
+      "version": "6.7.5",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "4.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-sandbox",
-  "version": "6.7.4",
+  "version": "6.7.5",
   "description": "Sandbox for Postman Scripts to run in Node.js or browser",
   "author": "Postman Inc.",
   "license": "Apache-2.0",

--- a/test/unit/execution.test.js
+++ b/test/unit/execution.test.js
@@ -37,4 +37,53 @@ describe('execution', function () {
         expect(json).to.not.have.nested.property('response.to');
         expect(execution).to.have.nested.property('response.to');
     });
+
+    it('does not freeze or reuse the caller report object', function () {
+        var callerReport = { summary: { requests: 42 } },
+            reportExecution = new Execution('id', { listen: 'test' }, { report: callerReport }, {});
+
+        expect(reportExecution.report).to.not.equal(callerReport);
+        expect(Object.isFrozen(reportExecution.report)).to.be.true;
+        expect(Object.isFrozen(reportExecution.report.summary)).to.be.true;
+        expect(Object.isFrozen(callerReport)).to.be.false;
+        expect(Object.isFrozen(callerReport.summary)).to.be.false;
+
+        callerReport.summary.requests = 100;
+        expect(reportExecution.report.summary.requests).to.equal(42);
+    });
+
+    it('does not include the report when serialized', function () {
+        var reportExecution = new Execution('id', { listen: 'test' }, {
+                report: { summary: { requests: 42 } }
+            }, {}),
+            json = reportExecution.toJSON();
+
+        expect(reportExecution).to.have.own.property('report');
+        expect(json).to.not.have.own.property('report');
+    });
+
+    it('rejects report accessors without invoking them', function () {
+        var accessorInvoked = false,
+            callerReport = {};
+
+        Object.defineProperty(callerReport, 'summary', {
+            enumerable: true,
+            get: function () {
+                accessorInvoked = true;
+
+                return {};
+            }
+        });
+
+        expect(function () {
+            new Execution('id', { listen: 'test' }, { report: callerReport }, {}); // eslint-disable-line no-new
+        }).to.throw(TypeError, 'sandbox: report contains an accessor');
+        expect(accessorInvoked).to.be.false;
+    });
+
+    it('rejects a report whose root is not a JSON object or null', function () {
+        expect(function () {
+            new Execution('id', { listen: 'test' }, { report: [] }, {}); // eslint-disable-line no-new
+        }).to.throw(TypeError, 'sandbox: report must be a JSON object or null');
+    });
 });

--- a/test/unit/sandbox-libraries/pm.test.js
+++ b/test/unit/sandbox-libraries/pm.test.js
@@ -81,6 +81,74 @@ describe('sandbox library - pm api', function () {
         });
     });
 
+    describe('report', function () {
+        it('should be absent when no report is supplied', function (done) {
+            context.execute(`
+                var assert = require('assert');
+
+                assert.strictEqual(pm.performanceTest, undefined);
+                assert.strictEqual(Object.hasOwn(pm, 'performanceTest'), false);
+                assert.strictEqual(pm.report, undefined);
+            `, done);
+        });
+
+        it('should expose a supplied JSON report', function (done) {
+            context.execute(`
+                var assert = require('assert');
+
+                assert.strictEqual(Object.hasOwn(pm, 'performanceTest'), true);
+                assert.strictEqual(pm.report, undefined);
+                assert.deepEqual(pm.performanceTest.output.report.json, {
+                    schemaVersion: '0.1.0-alpha.1',
+                    summary: { requests: { total: 42 } }
+                });
+            `, {
+                context: {
+                    report: {
+                        schemaVersion: '0.1.0-alpha.1',
+                        summary: { requests: { total: 42 } }
+                    }
+                }
+            }, done);
+        });
+
+        it('should expose a null JSON report when report generation was unavailable', function (done) {
+            context.execute(`
+                var assert = require('assert');
+
+                assert.strictEqual(Object.hasOwn(pm, 'performanceTest'), true);
+                assert.strictEqual(pm.performanceTest.output.report.json, null);
+            `, { context: { report: null } }, done);
+        });
+
+        it('should expose a deeply immutable JSON report', function (done) {
+            context.execute(`
+                var assert = require('assert');
+
+                assert.strictEqual(Object.isFrozen(pm.performanceTest), true);
+                assert.strictEqual(Object.isFrozen(pm.performanceTest.output), true);
+                assert.strictEqual(Object.isFrozen(pm.performanceTest.output.report), true);
+                assert.strictEqual(Object.isFrozen(pm.performanceTest.output.report.json), true);
+                assert.strictEqual(Object.isFrozen(pm.performanceTest.output.report.json.summary), true);
+                assert.strictEqual(Object.isFrozen(pm.performanceTest.output.report.json.operations), true);
+                assert.strictEqual(Object.isFrozen(pm.performanceTest.output.report.json.operations[0]), true);
+                assert.throws(function () {
+                    pm.performanceTest.output.report.json.operations.push({ name: 'changed' });
+                }, TypeError);
+
+                pm.performanceTest.output.report.json.summary.requests = 0;
+                assert.strictEqual(pm.performanceTest.output.report.json.summary.requests, 42);
+            `, {
+                context: {
+                    report: {
+                        summary: { requests: 42 },
+                        operations: [{ name: 'GET /health' }]
+                    }
+                }
+            }, done);
+        });
+    });
+
     describe('globals', function () {
         it('should be defined as VariableScope', function (done) {
             context.execute(`

--- a/types/sandbox/prerequest.d.ts
+++ b/types/sandbox/prerequest.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for postman-sandbox 6.6.1
+// Type definitions for postman-sandbox 6.7.5
 // Project: https://github.com/postmanlabs/postman-sandbox
 // Definitions by: PostmanLabs
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -116,6 +116,10 @@ declare class Postman {
      * The iterationData object contains data from the data file provided during a collection run.
      */
     iterationData: import("postman-collection").VariableScope;
+    /**
+     * Contains performance-test-only APIs supplied for this script execution.
+     */
+    readonly performanceTest: PerformanceTest | undefined;
     /**
      * The request object inside pm is a representation of the request for which this script is being run.
      * For a pre-request script, this is the request that is about to be sent and when in a test script,
@@ -243,6 +247,32 @@ declare interface DatasetHandle {
  * @param datasetId - The dataset ID.
  */
 declare type Datasets = (datasetId: string) => DatasetHandle;
+
+/**
+ * Completed main-workload report wrapper.
+ * @property json - Deeply immutable JSON report, or `null` when unavailable.
+ */
+declare type PerformanceTestReport = {
+    readonly json: {
+        [key: string]: any;
+    } | null;
+};
+
+/**
+ * Completed performance test output.
+ * @property report - Completed main-workload report.
+ */
+declare type PerformanceTestOutput = {
+    readonly report: PerformanceTestReport;
+};
+
+/**
+ * Performance-test-only APIs.
+ * @property output - Completed performance test output.
+ */
+declare type PerformanceTest = {
+    readonly output: PerformanceTestOutput;
+};
 
 declare interface Visualizer {
     /**

--- a/types/sandbox/test.d.ts
+++ b/types/sandbox/test.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for postman-sandbox 6.6.1
+// Type definitions for postman-sandbox 6.7.5
 // Project: https://github.com/postmanlabs/postman-sandbox
 // Definitions by: PostmanLabs
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -147,6 +147,10 @@ declare class Postman {
      */
     iterationData: import("postman-collection").VariableScope;
     /**
+     * Contains performance-test-only APIs supplied for this script execution.
+     */
+    readonly performanceTest: PerformanceTest | undefined;
+    /**
      * The request object inside pm is a representation of the request for which this script is being run.
      * For a pre-request script, this is the request that is about to be sent and when in a test script,
      * this is the representation of the request that was sent.
@@ -279,6 +283,32 @@ declare interface DatasetHandle {
  * @param datasetId - The dataset ID.
  */
 declare type Datasets = (datasetId: string) => DatasetHandle;
+
+/**
+ * Completed main-workload report wrapper.
+ * @property json - Deeply immutable JSON report, or `null` when unavailable.
+ */
+declare type PerformanceTestReport = {
+    readonly json: {
+        [key: string]: any;
+    } | null;
+};
+
+/**
+ * Completed performance test output.
+ * @property report - Completed main-workload report.
+ */
+declare type PerformanceTestOutput = {
+    readonly report: PerformanceTestReport;
+};
+
+/**
+ * Performance-test-only APIs.
+ * @property output - Completed performance test output.
+ */
+declare type PerformanceTest = {
+    readonly output: PerformanceTestOutput;
+};
 
 declare interface Visualizer {
     /**


### PR DESCRIPTION
## Summary

- expose a presence-gated `pm.performanceTest.output.report.json` API
- deep-clone and deeply freeze the JSON report inside the sandbox
- keep the report non-enumerable so execution results do not echo it
- generate readonly TypeScript declarations for prerequisite and test scripts

## Verification

- 364 unit tests passing, 7 pending on supported Node 18
- focused namespace, null, immutability, absence, and serialization tests passing
- generated declarations parse with TypeScript 3.9 and are deterministic
- lint and diff checks clean